### PR TITLE
Introduce HeaderButton Component and Containers

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure } from '@storybook/react';
 
  // automatically import all files ending in *.stories.js
-const req = require.context('../stories', true, /.stories.js$/);
+const req = require.context('../src', true, /.stories.js$/);
 function loadStories() {
   req.keys().forEach(filename => req(filename));
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.21",
+    "@fortawesome/free-solid-svg-icons": "^5.10.1",	
+    "@fortawesome/react-fontawesome": "^0.1.4",
     "@zooniverse/grommet-theme": "^2.1.0",
     "babel-preset-react-app": "^7.0.0",
     "formik": "^1.5.8",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.21",
-    "@fortawesome/free-solid-svg-icons": "^5.10.1",	
+    "@fortawesome/free-solid-svg-icons": "^5.10.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@zooniverse/grommet-theme": "^2.1.0",
     "babel-preset-react-app": "^7.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,12 @@
 import React from 'react'
 import { BrowserRouter as Router, Route } from 'react-router-dom'
-import merge from 'lodash/merge'
 import { Grommet } from 'grommet'
-import zooTheme from '@zooniverse/grommet-theme'
 import './App.css'
 import Home from './screens/Home'
 import Projects from './screens/ProjectsIndex'
-import baseTheme from './theme'
+import { mergedTheme } from './theme'
 
 function App() {
-  const mergedTheme = merge({}, zooTheme, baseTheme)
   return (
     <Router>
       <>

--- a/src/components/EditorHeader/components/HeaderButton/HeaderButton.js
+++ b/src/components/EditorHeader/components/HeaderButton/HeaderButton.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Button, Text } from 'grommet'
 import styled from 'styled-components'
+import PropTypes from 'prop-types'
 
 const CapitalText = styled(Text)`
   text-transform: uppercase;
@@ -16,6 +17,18 @@ function HeaderButton ({ icon, label, onClick }) {
       reverse
     />
   )
+}
+
+HeaderButton.defaultProps = {
+  icon: null,
+  label: '',
+  onClick: () => {}
+}
+
+HeaderButton.propTypes = {
+  icon: PropTypes.shape(),
+  label: PropTypes.string,
+  onClick: PropTypes.func
 }
 
 export default HeaderButton

--- a/src/components/EditorHeader/components/HeaderButton/HeaderButton.js
+++ b/src/components/EditorHeader/components/HeaderButton/HeaderButton.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Button, Text } from 'grommet'
+import styled from 'styled-components'
+
+const CapitalText = styled(Text)`
+  text-transform: uppercase;
+`
+function HeaderButton ({ icon, label, onClick }) {
+  return (
+    <Button
+      gap='xsmall'
+      icon={icon}
+      label={<CapitalText color='#5C5C5C'>{label}</CapitalText>}
+      onClick={onClick}
+      plain
+      reverse
+    />
+  )
+}
+
+export default HeaderButton

--- a/src/components/EditorHeader/components/HeaderButton/HeaderButtons.stories.js
+++ b/src/components/EditorHeader/components/HeaderButton/HeaderButtons.stories.js
@@ -5,6 +5,7 @@ import { mergedTheme } from '../../../../theme'
 import UndoButtonContainer from './UndoButtonContainer'
 import SaveButtonContainer from './SaveButtonContainer'
 import MoreButtonContainer from './MoreButtonContainer'
+import LayoutButtonContainer from './LayoutButtonContainer'
 
 storiesOf('HeaderButtons', module)
   .add('UndoButton', () => (
@@ -20,5 +21,10 @@ storiesOf('HeaderButtons', module)
   .add('MoreButton', () => (
     <Grommet theme={mergedTheme}>
       <MoreButtonContainer />
+    </Grommet>
+  ))
+  .add('LayoutButton', () => (
+    <Grommet theme={mergedTheme}>
+      <LayoutButtonContainer />
     </Grommet>
   ))

--- a/src/components/EditorHeader/components/HeaderButton/HeaderButtons.stories.js
+++ b/src/components/EditorHeader/components/HeaderButton/HeaderButtons.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Grommet } from 'grommet';
+import { mergedTheme } from '../../../../theme'
+import UndoButtonContainer from './UndoButtonContainer'
+import SaveButtonContainer from './SaveButtonContainer'
+import MoreButtonContainer from './MoreButtonContainer'
+
+storiesOf('HeaderButtons', module)
+  .add('UndoButton', () => (
+    <Grommet theme={mergedTheme}>
+      <UndoButtonContainer />
+    </Grommet>
+  ))
+  .add('SaveButton', () => (
+    <Grommet theme={mergedTheme}>
+      <SaveButtonContainer />
+    </Grommet>
+  ))
+  .add('MoreButton', () => (
+    <Grommet theme={mergedTheme}>
+      <MoreButtonContainer />
+    </Grommet>
+  ))

--- a/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+import HeaderButton from './HeaderButton'
+import { Box } from 'grommet'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPause } from '@fortawesome/free-solid-svg-icons'
+
+class LayoutButtonContainer extends Component {
+  constructor (props) {
+    super(props)
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick() {}
+
+  render () {
+    return (
+      <HeaderButton
+        icon={
+          <Box direction='row' gap='xxsmall'>
+            <FontAwesomeIcon color='#555555' icon={faPause} size='xs' />
+            <FontAwesomeIcon color='#555555' icon={faPause} rotation={90} size='xs' />
+          </Box>
+        }
+        label={'Layout'}
+        onClick={this.onClick}
+      />
+    )
+  }
+}
+
+export default LayoutButtonContainer

--- a/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.spec.js
@@ -1,12 +1,12 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import UndoButton from './UndoButton'
+import LayoutButtonContainer from './LayoutButtonContainer'
 
 let wrapper
 
 describe('Component > UndoButton', function () {
   beforeEach(function() {
-    wrapper = shallow(<UndoButton />);
+    wrapper = shallow(<LayoutButtonContainer />);
   })
 
   it('should render without crashing', function () {

--- a/src/components/EditorHeader/components/HeaderButton/MoreButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/MoreButtonContainer.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react'
+import HeaderButton from './HeaderButton'
+import { FormDown } from 'grommet-icons'
+
+class MoreButtonContainer extends Component {
+  constructor (props) {
+    super(props)
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick() {}
+
+  render () {
+    return (
+      <HeaderButton
+        icon={<FormDown color='#555555' size='small'/>}
+        label={'More'}
+        onClick={this.onClick}
+      />
+    )
+  }
+}
+
+export default MoreButtonContainer

--- a/src/components/EditorHeader/components/HeaderButton/MoreButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/MoreButtonContainer.js
@@ -13,7 +13,7 @@ class MoreButtonContainer extends Component {
   render () {
     return (
       <HeaderButton
-        icon={<FormDown color='#555555' size='small'/>}
+        icon={<FormDown color='#555555' size='medium'/>}
         label={'More'}
         onClick={this.onClick}
       />

--- a/src/components/EditorHeader/components/HeaderButton/MoreButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/MoreButtonContainer.spec.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import MoreButtonContainer from './MoreButtonContainer'
+
+let wrapper
+
+describe('Component > UndoButton', function () {
+  beforeEach(function() {
+    wrapper = shallow(<MoreButtonContainer />);
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/components/EditorHeader/components/HeaderButton/SaveButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/SaveButtonContainer.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react'
+import HeaderButton from './HeaderButton'
+import { Save } from 'grommet-icons'
+
+class SaveButtonContainer extends Component {
+  constructor (props) {
+    super(props)
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick() {}
+
+  render () {
+    return (
+      <HeaderButton
+        icon={<Save color='#555555' size='small'/>}
+        label={'Save'}
+        onClick={this.onClick}
+      />
+    )
+  }
+}
+
+export default SaveButtonContainer

--- a/src/components/EditorHeader/components/HeaderButton/SaveButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/SaveButtonContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import HeaderButton from './HeaderButton'
-import { Save } from 'grommet-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSave } from '@fortawesome/free-solid-svg-icons'
 
 class SaveButtonContainer extends Component {
   constructor (props) {
@@ -13,7 +14,7 @@ class SaveButtonContainer extends Component {
   render () {
     return (
       <HeaderButton
-        icon={<Save color='#555555' size='small'/>}
+        icon={<FontAwesomeIcon color='#555555' icon={faSave} size='xs' />}
         label={'Save'}
         onClick={this.onClick}
       />

--- a/src/components/EditorHeader/components/HeaderButton/SaveButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/SaveButtonContainer.spec.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import SaveButtonContainer from './SaveButtonContainer'
+
+let wrapper
+
+describe('Component > UndoButton', function () {
+  beforeEach(function() {
+    wrapper = shallow(<SaveButtonContainer />);
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/components/EditorHeader/components/HeaderButton/UndoButton.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/UndoButton.spec.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import UndoButton from './UndoButton'
+
+let wrapper
+
+describe('Component > UndoButton', function () {
+  beforeEach(function() {
+    wrapper = shallow(<UndoButton />);
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react'
+import HeaderButton from './HeaderButton'
+import { Refresh } from 'grommet-icons'
+
+class UndoButtonContainer extends Component {
+  constructor (props) {
+    super(props)
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick() {}
+
+  render () {
+    return (
+      <HeaderButton
+        icon={<Refresh color='#555555' size='small'/>}
+        label={'Undo'}
+        onClick={this.onClick}
+      />
+    )
+  }
+}
+
+export default UndoButtonContainer

--- a/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.spec.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import UndoButtonContainer from './UndoButtonContainer'
+
+let wrapper
+
+describe('Component > UndoButton', function () {
+  beforeEach(function() {
+    wrapper = shallow(<UndoButtonContainer />);
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/components/EditorHeader/components/HeaderButton/index.js
+++ b/src/components/EditorHeader/components/HeaderButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './UndoButton'

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Box, Text } from 'grommet'
+
+function EditorHeader (props) {
+  return (
+    <Box>
+      <Text>Hello World</Text>
+    </Box>
+  )
+}
+
+
+export default EditorHeader

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
@@ -1,11 +1,20 @@
 import React from 'react'
-import { Box, Text } from 'grommet'
+import { CheckBox, Text } from 'grommet'
+import styled from 'styled-components'
 
-function EditorHeader (props) {
+const CapitalText = styled(Text)`
+  text-transform: uppercase;
+`
+
+function EditorHeader ({ checked, onChange }) {
   return (
-    <Box>
-      <Text>Hello World</Text>
-    </Box>
+    <CheckBox
+      checked={checked}
+      label={<CapitalText color='#5C5C5C'>Mark As Approved</CapitalText>}
+      onChange={onChange}
+      reverse
+      toggle
+    />
   )
 }
 

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
@@ -6,7 +6,7 @@ const CapitalText = styled(Text)`
   text-transform: uppercase;
 `
 
-function EditorHeader ({ checked, onChange }) {
+function MarkApproved ({ checked, onChange }) {
   return (
     <CheckBox
       checked={checked}
@@ -19,4 +19,4 @@ function EditorHeader ({ checked, onChange }) {
 }
 
 
-export default EditorHeader
+export default MarkApproved

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.spec.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.spec.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import MarkApproved from './MarkApproved'
+
+let wrapper
+
+describe('Component > MarkApproved', function () {
+  beforeEach(function() {
+    wrapper = shallow(<MarkApproved />);
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.stories.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Grommet } from 'grommet';
+import zooTheme from '@zooniverse/grommet-theme'
+import MarkApproved from './MarkApproved'
+
+storiesOf('MarkApproved', module)
+  .add('Default', () => (
+    <Grommet theme={zooTheme}>
+      <MarkApproved />
+    </Grommet>
+  ))

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.stories.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Grommet } from 'grommet';
-import zooTheme from '@zooniverse/grommet-theme'
-import MarkApproved from './MarkApproved'
+import MarkApproved from './MarkApprovedContainer'
+import { mergedTheme } from '../../../../theme'
 
 storiesOf('MarkApproved', module)
   .add('Default', () => (
-    <Grommet theme={zooTheme}>
+    <Grommet theme={mergedTheme}>
       <MarkApproved />
     </Grommet>
   ))

--- a/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.js
@@ -2,8 +2,20 @@ import React, { Component } from 'react'
 import MarkApproved from './MarkApproved'
 
 class MarkApprovedContainer extends Component {
+  constructor (props) {
+    super(props)
+    this.onChange = this.onChange.bind(this);
+    this.state = {
+      checked: false
+    }
+  }
+
+  onChange() {
+    this.setState({ checked: !this.state.checked })
+  }
+
   render () {
-    return <MarkApproved />
+    return <MarkApproved checked={this.state.checked} onChange={this.onChange} />
   }
 }
 

--- a/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.js
@@ -1,0 +1,10 @@
+import React, { Component } from 'react'
+import MarkApproved from './MarkApproved'
+
+class MarkApprovedContainer extends Component {
+  render () {
+    return <MarkApproved />
+  }
+}
+
+export default MarkApprovedContainer

--- a/src/components/EditorHeader/components/MarkApproved/index.js
+++ b/src/components/EditorHeader/components/MarkApproved/index.js
@@ -1,0 +1,1 @@
+export { default } from './MarkApprovedContainer'

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -17,7 +17,6 @@ const Uppercase = styled(Text)`
 function FilmstripViewer ({ images, isOpen, onToggle }) {
   const actionText = isOpen ? 'Collapse' : 'Expand';
 
-
   return (
     <RoundedBox background='#FFFFFF' pad='small'>
       <Box direction='row' justify='between'>

--- a/src/components/FilmstripViewer/FilmstripViewer.stories.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.stories.js
@@ -1,9 +1,8 @@
 import React from 'react';
-
 import { storiesOf } from '@storybook/react';
 import { Box, Grommet } from 'grommet';
-import FilmstripViewer from '../src/components/FilmstripViewer'
 import zooTheme from '@zooniverse/grommet-theme'
+import FilmstripViewer from './FilmstripViewer'
 
 storiesOf('FilmstripViewer', module)
   .add('Default', () => (

--- a/src/components/FilmstripViewer/FilmstripViewer.stories.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Box, Grommet } from 'grommet';
 import zooTheme from '@zooniverse/grommet-theme'
-import FilmstripViewer from './FilmstripViewer'
+import FilmstripViewer from './FilmstripViewerContainer'
 
 storiesOf('FilmstripViewer', module)
   .add('Default', () => (

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,3 +1,6 @@
+import merge from 'lodash/merge'
+import zooTheme from '@zooniverse/grommet-theme'
+
 const theme = {
   global: {
     colors: {
@@ -18,7 +21,23 @@ const theme = {
     check: {
       radius: '0'
     },
-    size: '1em'
+    size: '1em',
+    gap: 'xxsmall',
+    toggle: {
+      extend: props => `
+      background-color: #D8D8D8;
+      border-color: #979797;
+      `,
+      knob: {
+        extend: ({ checked }) => `
+        background-color: #FFFFFF;
+        border: 2px solid #5C5C5C;
+        height: 1em;
+        width: 1em;
+        ${checked ? `margin: 0.15em 0;` : `margin: 0.15em`}
+        `
+      }
+    }
   },
   dataTable: {
     primary: {
@@ -27,7 +46,7 @@ const theme = {
   },
   formField: {
     label: {
-      margin: { "horizontal": "none" }
+      margin: { bottom: 'xsmall', horizontal: "none" }
     },
     margin: 'medium',
     extend: props => `
@@ -51,4 +70,5 @@ const theme = {
   }
 }
 
-module.exports = theme;
+const mergedTheme = merge({}, zooTheme, theme)
+export { mergedTheme, theme }

--- a/src/theme.js
+++ b/src/theme.js
@@ -21,7 +21,7 @@ const theme = {
     check: {
       radius: '0'
     },
-    size: '1em',
+    size: '1.35em',
     gap: 'xxsmall',
     toggle: {
       extend: props => `

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,6 +1007,33 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
+"@fortawesome/fontawesome-common-types@^0.2.22":
+  version "0.2.22"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.22.tgz#3f1328d232a0fd5de8484d833c8519426f39f016"
+  integrity sha512-QmEuZsipX5/cR9JOg0fsTN4Yr/9lieYWM8AQpmRa0eIfeOcl/HLYoEa366BCGRSrgNJEexuvOgbq9jnJ22IY5g==
+
+"@fortawesome/fontawesome-svg-core@^1.2.21":
+  version "1.2.22"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.22.tgz#9a6117c96c8b823c7d531000568ac75c3c02e123"
+  integrity sha512-Q941E4x8UfnMH3308n0qrgoja+GoqyiV846JTLoCcCWAKokLKrixCkq6RDBs8r+TtAWaLUrBpI+JFxQNX/WNPQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.22"
+
+"@fortawesome/free-solid-svg-icons@^5.10.1":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.10.2.tgz#61bcecce3aa5001fd154826238dfa840de4aa05a"
+  integrity sha512-9Os/GRUcy+iVaznlg8GKcPSQFpIQpAg14jF0DWsMdnpJfIftlvfaQCWniR/ex9FoOpSEOrlXqmUCFL+JGeciuA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.22"
+
+"@fortawesome/react-fontawesome@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz#18d61d9b583ca289a61aa7dccc05bd164d6bc9ad"
+  integrity sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==
+  dependencies:
+    humps "^2.0.1"
+    prop-types "^15.5.10"
+
 "@hapi/address@2.x.x":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.0.0.tgz#9f05469c88cb2fd3dcd624776b54ee95c312126a"
@@ -6954,6 +6981,11 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
 
 hyphenate-style-name@^1.0.1, hyphenate-style-name@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This PR introduces a `HeaderButton` functional component to render all buttons to be used in the header. I am using Font Awesome again because grommet-icons is lacking and I the package allows me to rotate icons with a prop (needed for the layout button). 

All buttons are visible in the storybook `yarn storybook`