### PR TITLE
Add Classifier Layout Controls

### DIFF
--- a/src/components/AggregatedTranscriptions/AggregatedTranscriptions.js
+++ b/src/components/AggregatedTranscriptions/AggregatedTranscriptions.js
@@ -26,7 +26,7 @@ const OverflowBox = styled(Box)`
 
 function AggregatedTranscriptions (props) {
   return (
-    <Box background='white' height='large' round='xsmall' width='large'>
+    <Box background='white' height='large' round='xsmall'>
       <Box
         border={{ color: 'light-5', side: 'bottom' }}
         direction='row'

--- a/src/components/AggregatedTranscriptions/AggregatedTranscriptions.stories.js
+++ b/src/components/AggregatedTranscriptions/AggregatedTranscriptions.stories.js
@@ -8,7 +8,9 @@ storiesOf('AggregatedTranscriptions', module)
   .add('Default', () => (
     <Grommet theme={mergedTheme}>
       <Box background='#D8D8D8' height='xlarge'>
-        <AggregatedTranscriptionsContainer />
+        <Box width='large'>
+          <AggregatedTranscriptionsContainer />
+        </Box>
       </Box>
     </Grommet>
   ))

--- a/src/components/AggregatedTranscriptions/AggregatedTranscriptionsContainer.js
+++ b/src/components/AggregatedTranscriptions/AggregatedTranscriptionsContainer.js
@@ -1,10 +1,6 @@
-import React, { Component } from 'react'
+import React from 'react'
 import AggregatedTranscriptions from './AggregatedTranscriptions'
 
-class AggregatedTranscriptionsContainer extends Component {
-  render () {
-    return <AggregatedTranscriptions />
-  }
+export default function AggregatedTranscriptionsContainer() {
+  return <AggregatedTranscriptions />
 }
-
-export default AggregatedTranscriptionsContainer

--- a/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
@@ -8,9 +8,9 @@ import HeaderButton from './HeaderButton'
 
 function LayoutButtonContainer() {
   const store = React.useContext(AppContext)
-  const onClick = e => { store.classifier.toggleLayout() }
-  const rowShade = store.classifier.layout === 'row' ? '#555555' : '#CCCCCC'
-  const columnShade = store.classifier.layout === 'column' ? '#555555' : '#CCCCCC'
+  const onClick = e => { store.editor.toggleLayout() }
+  const rowShade = store.editor.layout === 'row' ? '#555555' : '#CCCCCC'
+  const columnShade = store.editor.layout === 'column' ? '#555555' : '#CCCCCC'
 
   return (
     <HeaderButton

--- a/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
@@ -3,9 +3,11 @@ import HeaderButton from './HeaderButton'
 import { Box } from 'grommet'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPause } from '@fortawesome/free-solid-svg-icons'
+import AppContext from 'store'
 
 export default function LayoutButtonContainer() {
-  const onClick = e => { console.log('Layout Button Pressed') }
+  const store = React.useContext(AppContext)
+  const onClick = e => { store.classifier.toggleLayout() }
   return (
     <HeaderButton
       icon={

--- a/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/LayoutButtonContainer.js
@@ -1,19 +1,23 @@
 import React from 'react'
-import HeaderButton from './HeaderButton'
 import { Box } from 'grommet'
+import { observer } from 'mobx-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPause } from '@fortawesome/free-solid-svg-icons'
 import AppContext from 'store'
+import HeaderButton from './HeaderButton'
 
-export default function LayoutButtonContainer() {
+function LayoutButtonContainer() {
   const store = React.useContext(AppContext)
   const onClick = e => { store.classifier.toggleLayout() }
+  const rowShade = store.classifier.layout === 'row' ? '#555555' : '#CCCCCC'
+  const columnShade = store.classifier.layout === 'column' ? '#555555' : '#CCCCCC'
+
   return (
     <HeaderButton
       icon={
         <Box direction='row' gap='xxsmall'>
-          <FontAwesomeIcon color='#555555' icon={faPause} size='xs' />
-          <FontAwesomeIcon color='#555555' icon={faPause} rotation={90} size='xs' />
+          <FontAwesomeIcon color={rowShade} icon={faPause} size='xs' />
+          <FontAwesomeIcon color={columnShade} icon={faPause} rotation={90} size='xs' />
         </Box>
       }
       label={'Layout'}
@@ -21,3 +25,5 @@ export default function LayoutButtonContainer() {
     />
   )
 }
+
+export default observer(LayoutButtonContainer)

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -22,7 +22,7 @@ function SubjectViewerContainer() {
   const onMouseLeave = e => setTools(false)
 
   return (
-    <Box onMouseOver={onMouseOver} onMouseLeave={onMouseLeave} background={{ color: '#858585' }} height='large' width='large' round='xsmall'>
+    <Box onMouseOver={onMouseOver} onMouseLeave={onMouseLeave} background={{ color: '#858585' }} height='large' round='xsmall'>
       <SubjectViewerHeader />
       <RelativeBox fill>
         <AbsoluteBox margin='small'>

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -8,19 +8,52 @@ import FilmstripViewer from '../../components/FilmstripViewer'
 import AggregatedTranscriptions from '../../components/AggregatedTranscriptions'
 
 function Editor() {
+  const editorBox = React.useRef(null)
   const store = React.useContext(AppContext)
   const direction = store.classifier.layout
 
+  const [viewerSize, setViewerSize] = React.useState(50)
+  const [transcriberSize, setTranscriberSize] = React.useState(50)
+  const [isMoving, setMove] = React.useState(false)
+  const [currentPos, setPos] = React.useState()
+
+  const onMouseDown = e => {
+    setMove(true)
+    setPos({ x: e.clientX })
+  }
+  const resizePanels = (e) => {
+    const newViewerWidth = currentPos.x / editorBox.current.clientWidth * 100
+    const viewerWidth = newViewerWidth.toFixed(1)
+    const transcriberWidth = 100 - viewerWidth
+    setViewerSize(viewerWidth)
+    setTranscriberSize(transcriberWidth)
+  }
+  const onMouseUp = e => setMove(false)
+  const onMouseMove = e => {
+    if (isMoving) {
+      resizePanels()
+      setPos({ x: e.clientX })
+    }
+  }
+
   return (
     <Box>
-      <Box direction={direction} gap='xsmall' margin={{ horizontal: 'medium' }}>
-        <Box basis='1/2'>
+      <Box
+        direction={direction}
+        pad={{ horizontal: 'medium' }}
+        onMouseLeave={onMouseUp}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        ref={editorBox}
+      >
+        <Box basis={`${viewerSize}%`}>
           <SubjectViewer />
         </Box>
-        <Box align='center' justify='center'>
-          <Resizer direction={direction} />
-        </Box>
-        <Box basis='1/2'>
+        <Resizer
+          direction={direction}
+          onMouseDown={onMouseDown}
+        />
+        <Box basis={`${transcriberSize}%`}>
           <AggregatedTranscriptions />
         </Box>
       </Box>

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -19,20 +19,33 @@ function Editor() {
 
   const onMouseDown = e => {
     setMove(true)
-    setPos({ x: e.clientX })
+    setNewPosition(e);
+  }
+  const setNewPosition = e => {
+    const bounds = editorBox.current.getBoundingClientRect();
+    if (direction === 'row') {
+      setPos({ x: e.clientX - bounds.left })
+    } else {
+      setPos({ y: e.clientY - bounds.top })
+    }
   }
   const resizePanels = (e) => {
-    const newViewerWidth = currentPos.x / editorBox.current.clientWidth * 100
-    const viewerWidth = newViewerWidth.toFixed(1)
-    const transcriberWidth = 100 - viewerWidth
-    setViewerSize(viewerWidth)
-    setTranscriberSize(transcriberWidth)
+    let newViewerSize
+    if (direction === 'row') {
+      newViewerSize = currentPos.x / editorBox.current.clientWidth * 100
+    } else {
+      newViewerSize = currentPos.y / editorBox.current.clientHeight * 100
+    }
+    const viewerSize = newViewerSize.toFixed(0)
+    const transcriberSize = 100 - viewerSize
+    setViewerSize(viewerSize)
+    setTranscriberSize(transcriberSize)
   }
   const onMouseUp = e => setMove(false)
   const onMouseMove = e => {
     if (isMoving) {
       resizePanels()
-      setPos({ x: e.clientX })
+      setNewPosition(e)
     }
   }
 
@@ -40,20 +53,21 @@ function Editor() {
     <Box>
       <Box
         direction={direction}
+        height='large'
         pad={{ horizontal: 'medium' }}
         onMouseLeave={onMouseUp}
         onMouseMove={onMouseMove}
         onMouseUp={onMouseUp}
         ref={editorBox}
       >
-        <Box basis={`${viewerSize}%`}>
+        <Box fill basis={`${viewerSize}%`}>
           <SubjectViewer />
         </Box>
         <Resizer
           direction={direction}
           onMouseDown={onMouseDown}
         />
-        <Box basis={`${transcriberSize}%`}>
+        <Box fill basis={`${transcriberSize}%`}>
           <AggregatedTranscriptions />
         </Box>
       </Box>

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -49,6 +49,7 @@ function Editor() {
     if (isMoving) {
       resizePanels()
       setNewPosition(e)
+      e.preventDefault()
     }
   }
 

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Box } from 'grommet'
 import AppContext from 'store'
 import { observer } from 'mobx-react'
+import Resizer from './components/Resizer'
 import SubjectViewer from '../../components/SubjectViewer'
 import FilmstripViewer from '../../components/FilmstripViewer'
 import AggregatedTranscriptions from '../../components/AggregatedTranscriptions'
@@ -12,9 +13,12 @@ function Editor() {
 
   return (
     <Box>
-      <Box direction={direction} gap='small' margin={{ horizontal: 'medium' }}>
+      <Box direction={direction} gap='xsmall' margin={{ horizontal: 'medium' }}>
         <Box basis='1/2'>
           <SubjectViewer />
+        </Box>
+        <Box align='center' justify='center'>
+          <Resizer direction={direction} />
         </Box>
         <Box basis='1/2'>
           <AggregatedTranscriptions />

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -45,7 +45,6 @@ function Editor() {
       setTranscriberSize(transcriberSize)
     }
   }
-  const onMouseUp = e => setMove(false)
   const onMouseMove = e => {
     if (isMoving) {
       resizePanels()
@@ -54,30 +53,27 @@ function Editor() {
   }
 
   return (
-    <Box>
+    <Box gap='small' margin={{ horizontal: 'medium'}}>
       <Box
         direction={direction}
         height='large'
-        pad={{ horizontal: 'medium' }}
-        onMouseLeave={onMouseUp}
+        onMouseLeave={() => { setMove(false) }}
         onMouseMove={onMouseMove}
-        onMouseUp={onMouseUp}
+        onMouseUp={() => { setMove(false) }}
         ref={editorBox}
       >
-        <Box fill basis={`${viewerSize}%`}>
+        <Box basis={`${viewerSize}%`}>
           <SubjectViewer />
         </Box>
         <Resizer
           direction={direction}
           onMouseDown={onMouseDown}
         />
-        <Box fill basis={`${transcriberSize}%`}>
+        <Box basis={`${transcriberSize}%`}>
           <AggregatedTranscriptions />
         </Box>
       </Box>
-      <Box margin={{ horizontal: 'medium', top: 'small' }}>
-        <FilmstripViewer />
-      </Box>
+      <FilmstripViewer />
     </Box>
   )
 }

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -12,7 +12,7 @@ const MIN_WIDTH = 33;
 function Editor() {
   const editorBox = React.useRef(null)
   const store = React.useContext(AppContext)
-  const direction = store.classifier.layout
+  const direction = store.editor.layout
 
   const [viewerSize, setViewerSize] = React.useState(50)
   const [transcriberSize, setTranscriberSize] = React.useState(50)

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -1,15 +1,24 @@
 import React from 'react'
 import { Box } from 'grommet'
+import AppContext from 'store'
+import { observer } from 'mobx-react'
 import SubjectViewer from '../../components/SubjectViewer'
 import FilmstripViewer from '../../components/FilmstripViewer'
 import AggregatedTranscriptions from '../../components/AggregatedTranscriptions'
 
-export default () => {
+function Editor() {
+  const store = React.useContext(AppContext)
+  const direction = store.classifier.layout
+
   return (
     <Box>
-      <Box direction='row' gap='small' margin={{ horizontal: 'medium' }}>
-        <SubjectViewer />
-        <AggregatedTranscriptions />
+      <Box direction={direction} gap='small' margin={{ horizontal: 'medium' }}>
+        <Box basis='1/2'>
+          <SubjectViewer />
+        </Box>
+        <Box basis='1/2'>
+          <AggregatedTranscriptions />
+        </Box>
       </Box>
       <Box margin={{ horizontal: 'medium', top: 'small' }}>
         <FilmstripViewer />
@@ -17,3 +26,5 @@ export default () => {
     </Box>
   )
 }
+
+export default observer(Editor)

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -7,6 +7,8 @@ import SubjectViewer from '../../components/SubjectViewer'
 import FilmstripViewer from '../../components/FilmstripViewer'
 import AggregatedTranscriptions from '../../components/AggregatedTranscriptions'
 
+const MIN_WIDTH = 33;
+
 function Editor() {
   const editorBox = React.useRef(null)
   const store = React.useContext(AppContext)
@@ -38,8 +40,10 @@ function Editor() {
     }
     const viewerSize = newViewerSize.toFixed(0)
     const transcriberSize = 100 - viewerSize
-    setViewerSize(viewerSize)
-    setTranscriberSize(transcriberSize)
+    if (viewerSize > MIN_WIDTH && transcriberSize > MIN_WIDTH) {
+      setViewerSize(viewerSize)
+      setTranscriberSize(transcriberSize)
+    }
   }
   const onMouseUp = e => setMove(false)
   const onMouseMove = e => {

--- a/src/screens/Editor/components/Resizer.js
+++ b/src/screens/Editor/components/Resizer.js
@@ -1,26 +1,27 @@
 import React from 'react'
+import { Box } from 'grommet'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEllipsisH, faEllipsisV } from '@fortawesome/free-solid-svg-icons'
 import styled from 'styled-components'
 
-const StyledIcon = styled(FontAwesomeIcon)`
+const StyledBox = styled(Box)`
   :hover {
     cursor: ${props => props.direction === 'row' ? 'col-resize' : 'row-resize'};
   }
 `
 
-function mouseDown() {
-  console.log('MOUSE DOWN');
-}
-
-export default function Resizer({ direction }) {
+export default function Resizer({ direction, onMouseDown }) {
   const ellipsis = direction === 'row' ? faEllipsisV : faEllipsisH
 
   return (
-    <StyledIcon
+    <StyledBox
+      align='center'
       direction={direction}
-      icon={ellipsis}
-      onMouseDown={mouseDown}
-    />
+      justify='center'
+      onMouseDown={onMouseDown}
+      pad='xsmall'
+    >
+      <FontAwesomeIcon icon={ellipsis} />
+    </StyledBox>
   )
 }

--- a/src/screens/Editor/components/Resizer.js
+++ b/src/screens/Editor/components/Resizer.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEllipsisH, faEllipsisV } from '@fortawesome/free-solid-svg-icons'
+import styled from 'styled-components'
+
+const StyledIcon = styled(FontAwesomeIcon)`
+  :hover {
+    cursor: ${props => props.direction === 'row' ? 'col-resize' : 'row-resize'};
+  }
+`
+
+function mouseDown() {
+  console.log('MOUSE DOWN');
+}
+
+export default function Resizer({ direction }) {
+  const ellipsis = direction === 'row' ? faEllipsisV : faEllipsisH
+
+  return (
+    <StyledIcon
+      direction={direction}
+      icon={ellipsis}
+      onMouseDown={mouseDown}
+    />
+  )
+}

--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -1,10 +1,12 @@
 import { types } from 'mobx-state-tree'
 import { AuthStore } from './AuthStore'
+import { ClassifierStore } from './ClassifierStore'
 import { ImageStore } from './ImageStore'
 
 const AppStore = types.model('AppStore', {
   initialised: types.optional(types.boolean, false),
   auth: types.optional(AuthStore, () => AuthStore.create({})),
+  classifier: types.optional(ClassifierStore, () => ClassifierStore.create({})),
   image: types.optional(ImageStore, () => ImageStore.create({}))
 })
 

--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -1,12 +1,12 @@
 import { types } from 'mobx-state-tree'
 import { AuthStore } from './AuthStore'
-import { ClassifierStore } from './ClassifierStore'
+import { EditorStore } from './EditorStore'
 import { ImageStore } from './ImageStore'
 
 const AppStore = types.model('AppStore', {
   initialised: types.optional(types.boolean, false),
   auth: types.optional(AuthStore, () => AuthStore.create({})),
-  classifier: types.optional(ClassifierStore, () => ClassifierStore.create({})),
+  editor: types.optional(EditorStore, () => EditorStore.create({})),
   image: types.optional(ImageStore, () => ImageStore.create({}))
 })
 

--- a/src/store/ClassifierStore.js
+++ b/src/store/ClassifierStore.js
@@ -1,0 +1,16 @@
+import { types } from 'mobx-state-tree'
+
+const LAYOUT = {
+  ROW: 'row',
+  COLUMN: 'column'
+}
+
+const ClassifierStore = types.model('ClassifierStore', {
+  layout: types.optional(types.string, LAYOUT.ROW),
+}).actions(self => ({
+  toggleLayout() {
+    self.layout = (self.layout === LAYOUT.ROW) ? LAYOUT.COLUMN : LAYOUT.ROW
+  }
+}))
+
+export { ClassifierStore }

--- a/src/store/EditorStore.js
+++ b/src/store/EditorStore.js
@@ -5,7 +5,7 @@ const LAYOUT = {
   COLUMN: 'column'
 }
 
-const ClassifierStore = types.model('ClassifierStore', {
+const EditorStore = types.model('EditorStore', {
   layout: types.optional(types.string, LAYOUT.ROW),
 }).actions(self => ({
   toggleLayout() {
@@ -13,4 +13,4 @@ const ClassifierStore = types.model('ClassifierStore', {
   }
 }))
 
-export { ClassifierStore }
+export { EditorStore }


### PR DESCRIPTION
This PR adds two controls to the classifier. 

- Allow users to switch between landscape modes using the header button
- Allow users to change widths and heights of the subject and transcription viewers using the ellipsis drag handler.

[Editor page design](https://projects.invisionapp.com/d/?origin=v7?origin=v7#/console/17925240/371813754/preview)

Closes #34 