### PR TITLE
Setup docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/build
+**/dist
+**/node_modules
+**/.DS_Store
+Dockerfile
+docs
+plop
+plopfile.js
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10
+
+RUN mkdir -p /usr/src
+WORKDIR /usr/src/
+
+COPY ./ /usr/src
+RUN chown -R node:node .
+
+USER node
+
+RUN yarn install

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ A front end tool allowing reviewing and editing of Zooniverse transcription data
 ## Status
 This project is currently in development and projected to be completed February 2020.
 
-## Setup
-This project uses [yarn](https://yarnpkg.com) commands to get the app up and running
+## Getting Started
+This project uses [Yarn](https://yarnpkg.com/en/docs) or [Docker](https://docs.docker.com/) to get the app up and running
 
-**Steps:**  
+**Yarn**  
 - `yarn install` to install package dependencies  
 - `yarn test` to run all tests within the repo  
 - `yarn storybook` to open a [Storybook](https://storybook.js.org) viewer at `http://localhost:6006` to view components in isolation  
 - `yarn start` to open a staging version of the site at `http://localhost:3000`  
+
+**Docker**
+- `docker-compose up` to run the development app at `http://localhost:3000` and start storybook at `http://localhost:6006`
+- `docker-compose down` to stop the dev containers
+- `docker-compose run --rm dev test` to run the tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,13 @@ services:
     volumes:
       - ${PWD}:/src
       - /src/node_modules
+  storybook:
+    image: zooniverse-text-editor:latest
+    entrypoint:
+      - "yarn"
+    command: ["storybook"]
+    ports:
+      - "6006:6006"
+    volumes:
+      - ${PWD}:/src
+      - /src/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+
+services:
+  dev:
+    image: zooniverse-text-editor:latest
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    entrypoint:
+      - "yarn"
+    command: ["start"]
+    ports:
+      - "3000:3000"
+    volumes:
+      - ${PWD}:/src
+      - /src/node_modules


### PR DESCRIPTION
This PR sets up docker on the repo to quickly get the app up and running. With this PR, `docker-compose up` will run a dev version of the app and storybook together. I've also updated the README to reflect the new commands, which closes a recent issue.

Closes #14 

