### PR TITLE
Change config object

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path')
 
-module.exports = (baseConfig, env, config) => {
+module.exports = ({config}) => {
   config.resolve.modules = [
     ...(config.resolve.modules || []),
     path.resolve(__dirname, "../src")


### PR DESCRIPTION
Whoops! Jumping two major Storybook versions in [this PR](https://github.com/zooniverse/text-editor/pull/43) caused some breaking issues I was unaware of. 

From the official docs, [this](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#webpack-config-simplification) was the breaking change (webpack config simplification).