### PR TITLE
Remove Checkboxes from ResourcesTable

### DIFF
--- a/src/components/EditorHeader/components/HeaderButton/DownloadSetDataContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/DownloadSetDataContainer.js
@@ -5,7 +5,7 @@ export default function DownloadSetDataContainer() {
   const onClick = e => { console.log('Download Subject Set Button Pressed') }
   return (
     <HeaderButton
-      label={'Download Subject Set Data'}
+      label='Download Approved Subject Set Data'
       onClick={onClick}
     />
   )

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -1,39 +1,30 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Box, DataTable } from 'grommet'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 
-class ResourcesTable extends Component {
-  constructor() {
-    super()
 
-    this.onClickRow = this.onClickRow.bind(this);
-  }
-
-  onClickRow(e) {
-    if (this.props.onSelection) {
-      this.props.onSelection(e.datum)
+function ResourcesTable({ columns, data, history, onSelection }) {
+  const onClickRow = (e) => {
+    if (onSelection) {
+      onSelection(e.datum.id)
     } else {
-      const newLocation = this.props.history.location.pathname + e.datum.link
-      this.props.history.push(newLocation);
+      const newLocation = history.location.pathname + e.datum.link
+      history.push(newLocation);
     }
   }
 
-  render() {
-    const { columns, data } = this.props;
-
-    return (
-      <Box background='white' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
-        <DataTable
-          columns={[...columns].map(col => ({ ...col }))}
-          data={data}
-          onClickRow={this.onClickRow}
-          pad='xsmall'
-          primaryKey="id"
-        />
-      </Box>
-    )
-  }
+  return (
+    <Box background='white' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
+      <DataTable
+        columns={[...columns].map(col => ({ ...col }))}
+        data={data}
+        onClickRow={onClickRow}
+        pad='xsmall'
+        primaryKey="id"
+      />
+    </Box>
+  )
 }
 
 ResourcesTable.defaultProps = {

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Box, CheckBox, DataTable, FormField } from 'grommet'
+import { Box, DataTable } from 'grommet'
 import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 
@@ -7,30 +7,10 @@ class ResourcesTable extends Component {
   constructor() {
     super()
 
-    this.state = { checked: [], columns: [] }
-
-    this.onCheck = this.onCheck.bind(this);
-    this.onCheckAll = this.onCheckAll.bind(this);
     this.onClickRow = this.onClickRow.bind(this);
   }
 
-  onCheck(e, value) {
-    const { checked } = this.state;
-    if (e.target.checked) {
-      checked.push(value);
-      this.setState({ checked });
-    } else {
-      this.setState({ checked: checked.filter(item => item !== value) });
-    }
-  }
-
-  onCheckAll(e) {
-    this.setState({ checked: e.target.checked? this.props.data.map(datum => datum.id) : [] })
-  }
-
   onClickRow(e) {
-    if (e.target.type === 'checkbox') return;
-
     if (this.props.onSelection) {
       this.props.onSelection(e.datum)
     } else {
@@ -40,40 +20,12 @@ class ResourcesTable extends Component {
   }
 
   render() {
-    const { checked } = this.state;
-    const { columns, data, resource } = this.props;
+    const { columns, data } = this.props;
 
     return (
       <Box background='white' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
         <DataTable
-          columns={[
-            {
-              property: "checkbox",
-              render: datum => (
-                <FormField htmlFor={`${resource}_ID_${datum.id}`}>
-                  <CheckBox
-                    key={datum.name}
-                    id={`${resource}_ID_${datum.id}`}
-                    checked={checked.indexOf(datum.id) !== -1}
-                    onChange={e => this.onCheck(e, datum.id)}
-                  />
-                </FormField>
-              ),
-              header: (
-                <FormField htmlFor={`All_${resource}`}>
-                  <CheckBox
-                    checked={checked.length === data.length}
-                    id={`All_${resource}`}
-                    indeterminate={
-                      checked.length > 0 && checked.length < data.length
-                    }
-                    onChange={this.onCheckAll}
-                  />
-                </FormField>
-              ),
-            },
-            ...columns
-          ].map(col => ({ ...col }))}
+          columns={[...columns].map(col => ({ ...col }))}
           data={data}
           onClickRow={this.onClickRow}
           pad='xsmall'

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom'
 function ResourcesTable({ columns, data, history, onSelection }) {
   const onClickRow = (e) => {
     if (onSelection) {
-      onSelection(e.datum.id)
+      onSelection(e.datum)
     } else {
       const newLocation = history.location.pathname + e.datum.link
       history.push(newLocation);

--- a/src/components/ResourcesTable/ResourcesTable.spec.js
+++ b/src/components/ResourcesTable/ResourcesTable.spec.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import { BrowserRouter } from 'react-router-dom';
 import { DataTable } from 'grommet'
-import ResourcesTable, { ResourcesTable as UnwrappedTable } from './ResourcesTable'
+import { ResourcesTable } from './ResourcesTable'
 
 let wrapper;
 let html;
@@ -40,10 +40,7 @@ const DATA = [
 
 describe('Component > ResourcesTable', function () {
   beforeEach(function() {
-    wrapper = shallow(
-      <BrowserRouter>
-        <ResourcesTable columns={COLUMNS} data={DATA} />
-      </BrowserRouter>);
+    wrapper = shallow(<ResourcesTable columns={COLUMNS} data={DATA} />)
     html = wrapper.html()
   })
 
@@ -66,7 +63,7 @@ describe('Component > ResourcesTable', function () {
 
 describe('ResourcesTable functions', function () {
   beforeEach(function () {
-    wrapper = shallow(<UnwrappedTable columns={COLUMNS} data={DATA} history={history} />)
+    wrapper = shallow(<ResourcesTable columns={COLUMNS} data={DATA} history={history} />)
   })
 
   it('should push a link to the history object', function () {
@@ -78,48 +75,11 @@ describe('ResourcesTable functions', function () {
     table.onClickRow(mockEvent)
     expect(pushSpy).toHaveBeenCalledWith('/projects/123')
   })
-
-  it('should check all boxes with onCheckAll', function () {
-    const mockEvent = {
-      target: { checked: true }
-    }
-    const columns = wrapper.find(DataTable).props().columns[0];
-    const checkBox = columns.header.props.children.props
-    checkBox.onChange(mockEvent)
-    wrapper.update()
-    const checkedItems = wrapper.state().checked
-    expect(checkedItems).toEqual([DATA[0].id, DATA[1].id])
-  })
-
-  it('should check a single box with onCheck', function () {
-    const mockEvent = {
-      target: { checked: true }
-    }
-    const columns = wrapper.find(DataTable).props().columns[0]
-    const checkboxColumn = columns.render(DATA[0]);
-    const checkboxChild = checkboxColumn.props.children
-    checkboxChild.props.onChange(mockEvent);
-    wrapper.update()
-    expect(wrapper.state().checked).toStrictEqual([DATA[0].id])
-  })
-
-  it('should uncheck an item with onCheck', function () {
-    const mockEvent = {
-      target: { checked: false }
-    }
-    wrapper.setState({ checked: [DATA[0].id] })
-    const columns = wrapper.find(DataTable).props().columns[0]
-    const checkboxColumn = columns.render(DATA[0]);
-    const checkboxChild = checkboxColumn.props.children
-    checkboxChild.props.onChange(mockEvent);
-    wrapper.update()
-    expect(wrapper.state().checked.length).toBe(0)
-  })
 })
 
 describe('ResourcesTable onSelection prop', function () {
   beforeEach(function () {
-    wrapper = shallow(<UnwrappedTable columns={COLUMNS} data={DATA} onSelection={onSelectionSpy} />)
+    wrapper = shallow(<ResourcesTable columns={COLUMNS} data={DATA} onSelection={onSelectionSpy} />)
   })
 
   it('should call the onSelection prop', function () {


### PR DESCRIPTION
This PR removes checkboxes from the resources table as they're no longer needed [per InVision](https://projects.invisionapp.com/d/#/console/17925240/375544496/preview). I also updated the phrasing of the subject set download button above as that was the original impetus for the change.