### PR TITLE
Search Modal Functions

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3134,7 +3134,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
       className="StyledBox-sc-13pk1d4-0 jLJOXa"
     >
       <div
-        className="StyledBox-sc-13pk1d4-0 juVmUb"
+        className="StyledBox-sc-13pk1d4-0 kULYLq"
       >
         <div
           className="StyledBox-sc-13pk1d4-0 fWrrBh"
@@ -3205,7 +3205,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
                     htmlFor="type"
                   >
-                    ID Type
+                    ID TYPE
                   </label>
                   <div
                     className="StyledBox-sc-13pk1d4-0 cLmlkO"
@@ -3273,7 +3273,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
                     htmlFor="id"
                   >
-                    Name
+                    NAME
                   </label>
                   <div
                     className="StyledBox-sc-13pk1d4-0 cLmlkO"
@@ -3294,6 +3294,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         onKeyDown={[Function]}
                         placeholder="eg. 58674"
                         size="small"
+                        value=""
                       />
                     </div>
                   </div>
@@ -3335,7 +3336,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       checked={false}
                       className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
                       disabled={false}
-                      htmlFor="unreviewed"
+                      htmlFor="unseen"
                       onClick={[Function]}
                     >
                       <div
@@ -3347,8 +3348,8 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                           checked={false}
                           className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
                           disabled={false}
-                          id="unreviewed"
-                          name="unreviewed"
+                          id="unseen"
+                          name="unseen"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3364,7 +3365,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         className="StyledText-sc-1sadyjn-0 bEMqcB"
                         size="small"
                       >
-                        UNREVIEWED
+                        UNSEEN
                       </span>
                     </label>
                   </div>
@@ -3382,7 +3383,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       checked={false}
                       className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
                       disabled={false}
-                      htmlFor="inProgress"
+                      htmlFor="in_progress"
                       onClick={[Function]}
                     >
                       <div
@@ -3394,8 +3395,8 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                           checked={false}
                           className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
                           disabled={false}
-                          id="inProgress"
-                          name="inProgress"
+                          id="in_progress"
+                          name="in_progress"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3429,7 +3430,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       checked={false}
                       className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
                       disabled={false}
-                      htmlFor="readyForReview"
+                      htmlFor="ready"
                       onClick={[Function]}
                     >
                       <div
@@ -3441,8 +3442,8 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                           checked={false}
                           className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
                           disabled={false}
-                          id="readyForReview"
-                          name="readyForReview"
+                          id="ready"
+                          name="ready"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3561,7 +3562,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         className="StyledText-sc-1sadyjn-0 bEMqcB"
                         size="small"
                       >
-                        Flagged
+                        FLAGGED
                       </span>
                     </label>
                   </div>
@@ -3579,7 +3580,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       checked={false}
                       className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
                       disabled={false}
-                      htmlFor="lowConsensus"
+                      htmlFor="low_consensus"
                       onClick={[Function]}
                     >
                       <div
@@ -3591,8 +3592,8 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                           checked={false}
                           className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
                           disabled={false}
-                          id="lowConsensus"
-                          name="lowConsensus"
+                          id="low_consensus"
+                          name="low_consensus"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -3608,7 +3609,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         className="StyledText-sc-1sadyjn-0 bEMqcB"
                         size="small"
                       >
-                        Low consensus score
+                        LOW CONSENSUS SCORE
                       </span>
                     </label>
                   </div>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -3567,53 +3567,6 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                     </label>
                   </div>
                 </div>
-                <div
-                  className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
-                />
-                <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO"
-                >
-                  <div
-                    className="StyledBox-sc-13pk1d4-0 cLmlkO"
-                  >
-                    <label
-                      checked={false}
-                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
-                      disabled={false}
-                      htmlFor="low_consensus"
-                      onClick={[Function]}
-                    >
-                      <div
-                        checked={false}
-                        className="StyledBox-sc-13pk1d4-0 ijCAgr StyledCheckBox-sc-1dbk5ju-6 jXdLin"
-                        disabled={false}
-                      >
-                        <input
-                          checked={false}
-                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
-                          disabled={false}
-                          id="low_consensus"
-                          name="low_consensus"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                        />
-                        <div
-                          checked={false}
-                          className="StyledBox-sc-13pk1d4-0 SUcEn StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
-                          disabled={false}
-                        />
-                      </div>
-                      <span
-                        className="StyledText-sc-1sadyjn-0 bEMqcB"
-                        size="small"
-                      >
-                        LOW CONSENSUS SCORE
-                      </span>
-                    </label>
-                  </div>
-                </div>
               </div>
             </div>
             <div

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -44,7 +44,7 @@ function ResourcesTable(props) {
       {props.data.length === 0 && props.status === ASYNC_STATES.READY && (
         <Text textAlign='center'>{`Sorry, we couldn't find any ${props.resource}`}</Text>
       )}
-      <Box margin={{ top: 'small' }}>
+      <Box align='center' margin={{ top: 'small' }}>
         <StepNavigation
           activeStep={props.activeStep}
           setStep={props.setStep}

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -6,7 +6,7 @@ import ASYNC_STATES from 'helpers/asyncStates'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import StepNavigation from '../StepNavigation'
-
+import SearchTags from './components/SearchTags'
 
 function ResourcesTable(props) {
   const onClickRow = (e) => {
@@ -20,7 +20,7 @@ function ResourcesTable(props) {
 
   return (
     <Box align='center' background='white' fill='horizontal' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
-      {props.searching && <Text>Actively Searching</Text>}
+      {props.searching && <SearchTags />}
 
       {props.data.length > 0 &&
         <DataTable

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -20,6 +20,8 @@ function ResourcesTable(props) {
 
   return (
     <Box align='center' background='white' fill='horizontal' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
+      {props.searching && <Text>Actively Searching</Text>}
+
       {props.data.length > 0 &&
         <DataTable
           columns={[...props.columns].map(col => ({ ...col }))}
@@ -61,6 +63,7 @@ ResourcesTable.defaultProps = {
   error: '',
   onSelection: null,
   resource: null,
+  searching: false,
   setStep: () => {},
   status: ASYNC_STATES.IDLE,
   steps: []
@@ -73,6 +76,7 @@ ResourcesTable.propTypes = {
   error: PropTypes.string,
   onSelection: PropTypes.func,
   resource: PropTypes.string,
+  searching: PropTypes.bool,
   setStep: PropTypes.func,
   steps: PropTypes.array,
   status: PropTypes.string

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -19,7 +19,7 @@ function ResourcesTable(props) {
   }
 
   return (
-    <Box align='center' background='white' fill='horizontal' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
+    <Box background='white' fill='horizontal' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
       {props.searching && <SearchTags />}
 
       {props.data.length > 0 &&

--- a/src/components/ResourcesTable/ResourcesTable.spec.js
+++ b/src/components/ResourcesTable/ResourcesTable.spec.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { DataTable, Text } from 'grommet'
 import ASYNC_STATES from 'helpers/asyncStates'
 import { ResourcesTable } from './ResourcesTable'
+import SearchTags from './components/SearchTags'
 
 let wrapper;
 let html;
@@ -58,6 +59,11 @@ describe('Component > ResourcesTable', function () {
     expect(html).toContain(DATA[0].secondColumn);
     expect(html).toContain(DATA[1].firstColumn);
     expect(html).toContain(DATA[1].secondColumn);
+  })
+
+  it('should render the SearchTags component', function () {
+    wrapper = shallow(<ResourcesTable columns={COLUMNS} data={DATA} searching />)
+    expect(wrapper.find(SearchTags).length).toBe(1)
   })
 })
 

--- a/src/components/ResourcesTable/components/SearchTags/SearchTag.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTag.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Box, Text } from 'grommet'
+import { string } from 'prop-types'
+
+function SearchTag({ tag }) {
+  return (
+    <Box>
+      <Text>{tag}</Text>
+    </Box>
+  )
+}
+
+SearchTag.propTypes = {
+  tag: string
+}
+
+SearchTag.defaultProps = {
+  tag: ''
+}
+
+export default SearchTag

--- a/src/components/ResourcesTable/components/SearchTags/SearchTag.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTag.js
@@ -1,21 +1,44 @@
 import React from 'react'
-import { Box, Text } from 'grommet'
-import { string } from 'prop-types'
+import { Box, Button, Text } from 'grommet'
+import { func, string } from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons'
+import styled from 'styled-components'
 
-function SearchTag({ tag }) {
+const CapitalText = styled(Text)`
+  text-transform: uppercase;
+`
+
+function SearchTag({ clearTag, tag, value }) {
   return (
-    <Box>
-      <Text>{tag}</Text>
+    <Box
+      align='center'
+      background='light-2'
+      direction='row'
+      gap='xsmall'
+      pad='xsmall'
+      round='xsmall'
+    >
+      <CapitalText>{tag}: {value}</CapitalText>
+      <Button
+        label={<FontAwesomeIcon icon={faTimesCircle} size='xs' />}
+        onClick={() => clearTag(tag)}
+        plain
+      />
     </Box>
   )
 }
 
 SearchTag.propTypes = {
-  tag: string
+  clearTag: func,
+  tag: string,
+  value: string
 }
 
 SearchTag.defaultProps = {
-  tag: ''
+  clearTag: () => {},
+  tag: '',
+  value: ''
 }
 
 export default SearchTag

--- a/src/components/ResourcesTable/components/SearchTags/SearchTag.spec.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTag.spec.js
@@ -1,15 +1,23 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import { Button } from 'grommet'
 import SearchTag from './SearchTag'
 
 let wrapper
+const clearTagSpy = jest.fn()
 
 describe('Component > SearchTag', function () {
   beforeEach(function() {
-    wrapper = shallow(<SearchTag />);
+    wrapper = shallow(<SearchTag clearTag={clearTagSpy} />);
   })
 
   it('should render without crashing', function () {
     expect(wrapper).toBeDefined()
+  })
+
+  it('should trigger the clearTag prop', function () {
+    const closeBtn = wrapper.find(Button).first()
+    closeBtn.props().onClick()
+    expect(clearTagSpy).toHaveBeenCalled()
   })
 })

--- a/src/components/ResourcesTable/components/SearchTags/SearchTag.spec.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTag.spec.js
@@ -1,0 +1,15 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import SearchTag from './SearchTag'
+
+let wrapper
+
+describe('Component > SearchTag', function () {
+  beforeEach(function() {
+    wrapper = shallow(<SearchTag />);
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import AppContext from 'store'
+import { Box, Text } from 'grommet'
+import SearchTag from './SearchTag'
+
+function SearchTagContainer() {
+  const store = React.useContext(AppContext)
+  const activeTags = Object.keys(store.search).filter(key => store.search[key] || store.search[key].length > 0);
+
+  return (
+    <Box>
+      <Text>Search Results</Text>
+      {activeTags.map(tag => <SearchTag key={`SEARCH_TAG_${tag}`} clearTag={store.search.clearTag} tag={tag}/>)}
+    </Box>
+  )
+}
+
+export default SearchTagContainer

--- a/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
@@ -22,7 +22,6 @@ function SearchTagContainer() {
         )
       })}
       {idTag && <SearchTag clearTag={store.search.clearIdTags} tag={store.search.type} value={store.search.id} />}
-
     </Box>
   )
 }

--- a/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
@@ -8,9 +8,18 @@ function SearchTagContainer() {
   const activeTags = Object.keys(store.search).filter(key => store.search[key] || store.search[key].length > 0);
 
   return (
-    <Box>
-      <Text>Search Results</Text>
-      {activeTags.map(tag => <SearchTag key={`SEARCH_TAG_${tag}`} clearTag={store.search.clearTag} tag={tag}/>)}
+    <Box align='baseline' direction='row' gap='small'>
+      <Text size='large'>Search Results</Text>
+      {activeTags.map(tag => {
+        return (
+          <SearchTag
+            key={`SEARCH_TAG_${tag}`}
+            clearTag={store.search.clearTag}
+            tag={tag}
+            value={store.search[tag].toString()}
+          />
+        )
+      })}
     </Box>
   )
 }

--- a/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.js
@@ -5,12 +5,13 @@ import SearchTag from './SearchTag'
 
 function SearchTagContainer() {
   const store = React.useContext(AppContext)
-  const activeTags = Object.keys(store.search).filter(key => store.search[key] || store.search[key].length > 0);
+  const booleanTags = Object.keys(store.search).filter(key => store.search[key] === true);
+  const idTag = store.search.id.length > 0 && store.search.type.length > 0
 
   return (
     <Box align='baseline' direction='row' gap='small'>
       <Text size='large'>Search Results</Text>
-      {activeTags.map(tag => {
+      {booleanTags.map(tag => {
         return (
           <SearchTag
             key={`SEARCH_TAG_${tag}`}
@@ -20,6 +21,8 @@ function SearchTagContainer() {
           />
         )
       })}
+      {idTag && <SearchTag clearTag={store.search.clearIdTags} tag={store.search.type} value={store.search.id} />}
+
     </Box>
   )
 }

--- a/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.spec.js
+++ b/src/components/ResourcesTable/components/SearchTags/SearchTagContainer.spec.js
@@ -1,0 +1,25 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import SearchTagContainer from './SearchTagContainer'
+
+let wrapper
+const contextValues = {
+  search: {
+    approved: true,
+    id: '1',
+    type: 'ZOONIVERSE ID'
+  }
+}
+
+describe('Component > SearchTagContainer', function () {
+  beforeEach(function() {
+    jest
+      .spyOn(React, 'useContext')
+      .mockImplementation(() => contextValues )
+    wrapper = shallow(<SearchTagContainer />);
+  })
+
+  it('should render without crashing', function () {
+    expect(wrapper).toBeDefined()
+  })
+})

--- a/src/components/ResourcesTable/components/SearchTags/index.js
+++ b/src/components/ResourcesTable/components/SearchTags/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchTagContainer'

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -7,7 +7,7 @@ import { Formik } from 'formik'
 import withThemeContext from '../../helpers/withThemeContext'
 import theme from './theme'
 import SearchCheckBox from './components/SearchCheckBox'
-import { TYPES } from './SearchModalContainer'
+import { TYPES } from 'store/SearchStore'
 
 const CapitalText = styled(Text)`
   text-transform: uppercase;
@@ -77,7 +77,7 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
                         setValue(option)
                       }}
                       plain
-                      value={<Text>{value}</Text>}
+                      value={<Text>{values.type || value}</Text>}
                     />
                   </ReverseFormField>
                 </Box>
@@ -91,6 +91,7 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
                       onChange={handleChange}
                       placeholder='eg. 58674'
                       size='small'
+                      value={values.id}
                     />
                   </ReverseFormField>
                 </Box>

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -7,7 +7,7 @@ import { Formik } from 'formik'
 import withThemeContext from '../../helpers/withThemeContext'
 import theme from './theme'
 import SearchCheckBox from './components/SearchCheckBox'
-import { TYPES } from 'store/SearchStore'
+import { FILTERS, TYPES } from 'store/SearchStore'
 
 const CapitalText = styled(Text)`
   text-transform: uppercase;
@@ -100,52 +100,52 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
               <Box direction='row' justify='between'>
                 <Box gap='small'>
                   <Text weight='bold'>Approval Status</Text>
-                  <FormField htmlFor='unseen'>
+                  <FormField htmlFor={FILTERS.UNSEEN}>
                     <SearchCheckBox
                       checked={values.unseen}
                       disabled={disableCheckbox}
                       label='UNSEEN'
                       onChange={handleChange}
-                      title='unseen'
+                      title={FILTERS.UNSEEN}
                     />
                   </FormField>
-                  <FormField htmlFor='in_progress'>
+                  <FormField htmlFor={FILTERS.IN_PROGRESS}>
                     <SearchCheckBox
                       checked={values.in_progress}
                       disabled={disableCheckbox}
                       label='IN PROGRESS'
                       onChange={handleChange}
-                      title='in_progress'
+                      title={FILTERS.IN_PROGRESS}
                     />
                   </FormField>
-                  <FormField htmlFor='ready'>
+                  <FormField htmlFor={FILTERS.READY}>
                     <SearchCheckBox
                       checked={values.ready}
                       disabled={disableCheckbox}
                       label='READY FOR REVIEW'
                       onChange={handleChange}
-                      title='ready'
+                      title={FILTERS.READY}
                     />
                   </FormField>
-                  <FormField htmlFor='approved'>
+                  <FormField htmlFor={FILTERS.APPROVED}>
                     <SearchCheckBox
                       checked={values.approved}
                       disabled={disableCheckbox}
                       label='APPROVED'
                       onChange={handleChange}
-                      title='approved'
+                      title={FILTERS.APPROVED}
                     />
                   </FormField>
                 </Box>
                 <Box gap='small'>
                   <Text weight='bold'>Additional Filters</Text>
-                  <FormField htmlFor='flagged'>
+                  <FormField htmlFor={FILTERS.FLAGGED}>
                     <SearchCheckBox
                       checked={values.flagged}
                       disabled={disableCheckbox}
                       label='FLAGGED'
                       onChange={handleChange}
-                      title='flagged'
+                      title={FILTERS.FLAGGED}
                     />
                   </FormField>
                 </Box>

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -99,13 +99,13 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
               <Box direction='row' justify='between'>
                 <Box gap='small'>
                   <Text weight='bold'>Approval Status</Text>
-                  <FormField htmlFor='unreviewed'>
+                  <FormField htmlFor='unseen'>
                     <SearchCheckBox
-                      checked={values.unreviewed}
+                      checked={values.unseen}
                       disabled={disableCheckbox}
-                      label='UNREVIEWED'
+                      label='UNSEEN'
                       onChange={handleChange}
-                      title='unreviewed'
+                      title='unseen'
                     />
                   </FormField>
                   <FormField htmlFor='inProgress'>
@@ -117,13 +117,13 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
                       title='inProgress'
                     />
                   </FormField>
-                  <FormField htmlFor='readyForReview'>
+                  <FormField htmlFor='ready'>
                     <SearchCheckBox
-                      checked={values.readyForReview}
+                      checked={values.ready}
                       disabled={disableCheckbox}
                       label='READY FOR REVIEW'
                       onChange={handleChange}
-                      title='readyForReview'
+                      title='ready'
                     />
                   </FormField>
                   <FormField htmlFor='approved'>
@@ -142,18 +142,18 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
                     <SearchCheckBox
                       checked={values.flagged}
                       disabled={disableCheckbox}
-                      label='Flagged'
+                      label='FLAGGED'
                       onChange={handleChange}
                       title='flagged'
                     />
                   </FormField>
-                  <FormField htmlFor='lowConsensus'>
+                  <FormField htmlFor='low_consensus'>
                     <SearchCheckBox
-                      checked={values.lowConsensus}
+                      checked={values.low_consensus}
                       disabled={disableCheckbox}
-                      label='Low consensus score'
+                      label='LOW CONSENSUS SCORE'
                       onChange={handleChange}
-                      title='lowConsensus'
+                      title='low_consensus'
                     />
                   </FormField>
                 </Box>

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -39,7 +39,7 @@ const validateForm = (values) => {
 
 function SearchModal({ onClose, onSubmit, initialValues, options, setValue, value }) {
   return (
-    <Box background='white' pad='small' round='xsmall'>
+    <Box background='white' elevation='medium' pad='small' round='xsmall' width='25em'>
       <Box gap='small'>
         <Box align='center' direction='row' justify='between'>
           <Text size='large'>Search or Filter</Text>
@@ -65,7 +65,7 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
             <Box as='form' onSubmit={handleSubmit} gap='small'>
               <Box direction='row' gap='xsmall' margin={{ bottom: 'xsmall' }}>
                 <Box basis='1/3'>
-                  <ReverseFormField htmlFor='type' label='ID Type' error={errors && errors.type}>
+                  <ReverseFormField htmlFor='type' label='ID TYPE' error={errors && errors.type}>
                     <Select
                       disabled={disableInput}
                       dropAlign={{ top: 'top' }}
@@ -82,7 +82,7 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
                   </ReverseFormField>
                 </Box>
                 <Box basis='2/3'>
-                  <ReverseFormField htmlFor='id' label='Name' error={errors && errors.id}>
+                  <ReverseFormField htmlFor='id' label='NAME' error={errors && errors.id}>
                     <TextInput
                       color='red'
                       disabled={disableInput}

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -108,13 +108,13 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
                       title='unseen'
                     />
                   </FormField>
-                  <FormField htmlFor='inProgress'>
+                  <FormField htmlFor='in_progress'>
                     <SearchCheckBox
-                      checked={values.inProgress}
+                      checked={values.in_progress}
                       disabled={disableCheckbox}
                       label='IN PROGRESS'
                       onChange={handleChange}
-                      title='inProgress'
+                      title='in_progress'
                     />
                   </FormField>
                   <FormField htmlFor='ready'>

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -148,15 +148,6 @@ function SearchModal({ onClose, onSubmit, initialValues, options, setValue, valu
                       title='flagged'
                     />
                   </FormField>
-                  <FormField htmlFor='low_consensus'>
-                    <SearchCheckBox
-                      checked={values.low_consensus}
-                      disabled={disableCheckbox}
-                      label='LOW CONSENSUS SCORE'
-                      onChange={handleChange}
-                      title='low_consensus'
-                    />
-                  </FormField>
                 </Box>
               </Box>
               <Box direction='row' justify='between' margin={{ top: 'small' }}>

--- a/src/components/SearchModal/SearchModal.spec.js
+++ b/src/components/SearchModal/SearchModal.spec.js
@@ -12,9 +12,9 @@ let setValueSpy = jest.fn()
 const initialValues = {
   id: null,
   type: '',
-  unreviewed: false,
+  unseen: false,
   inProgress: false,
-  readyForReview: false,
+  ready: false,
   approved: false,
   flagged: false,
   lowConsensus: false,

--- a/src/components/SearchModal/SearchModal.spec.js
+++ b/src/components/SearchModal/SearchModal.spec.js
@@ -13,7 +13,7 @@ const initialValues = {
   id: null,
   type: '',
   unseen: false,
-  inProgress: false,
+  in_progress: false,
   ready: false,
   approved: false,
   flagged: false,

--- a/src/components/SearchModal/SearchModal.spec.js
+++ b/src/components/SearchModal/SearchModal.spec.js
@@ -51,4 +51,38 @@ describe('Component > SearchModal', function () {
       expect(setValueSpy).toBeCalledWith(option)
     })
   })
+
+  describe('form validations', function () {
+    let formValidation
+
+    beforeEach(function () {
+      formValidation = wrapper.find(Formik).first().props().validate
+    })
+
+    it('should require a type', function () {
+      const outcome = formValidation(initialValues)
+      expect(outcome).toEqual({
+        type: 'Type is required'
+      })
+    })
+
+    it('should require an ID', function () {
+      const copiedValues = Object.assign({}, initialValues)
+      copiedValues.type = 'ZOONIVERSE ID'
+      const outcome = formValidation(copiedValues)
+      expect(outcome).toEqual({
+        id: 'You must enter an ID'
+      })
+    })
+
+    it('should require Zooniverse ID to be a number', function () {
+      const copiedValues = Object.assign({}, initialValues)
+      copiedValues.type = 'ZOONIVERSE ID'
+      copiedValues.id = 'some id'
+      const outcome = formValidation(copiedValues)
+      expect(outcome).toEqual({
+        id: 'Zooniverse ID must be a number'
+      })
+    })
+  })
 })

--- a/src/components/SearchModal/SearchModalContainer.js
+++ b/src/components/SearchModal/SearchModalContainer.js
@@ -2,22 +2,7 @@ import React from 'react'
 import { observer } from 'mobx-react'
 import AppContext from 'store'
 import SearchModal from './SearchModal'
-
-const TYPES = {
-  ZOONIVERSE: 'ZOONIVERSE ID',
-  INTERNAL: 'INTERNAL ID'
-}
-
-const initialValues = {
-  id: null,
-  type: '',
-  unseen: false,
-  in_progress: false,
-  ready: false,
-  approved: false,
-  flagged: false,
-  low_consensus: false,
-}
+import { TYPES } from 'store/SearchStore'
 
 function SearchModalContainer() {
   const [value, setValue] = React.useState('Select...');
@@ -27,7 +12,7 @@ function SearchModalContainer() {
 
   return (
     <SearchModal
-      initialValues={initialValues}
+      initialValues={store.search}
       onClose={onClose}
       onSubmit={onSubmit}
       options={[ TYPES.ZOONIVERSE, TYPES.INTERNAL ]}
@@ -38,5 +23,4 @@ function SearchModalContainer() {
   )
 }
 
-export { TYPES }
 export default observer(SearchModalContainer)

--- a/src/components/SearchModal/SearchModalContainer.js
+++ b/src/components/SearchModal/SearchModalContainer.js
@@ -12,7 +12,7 @@ const initialValues = {
   id: null,
   type: '',
   unseen: false,
-  inProgress: false,
+  in_progress: false,
   ready: false,
   approved: false,
   flagged: false,

--- a/src/components/SearchModal/SearchModalContainer.js
+++ b/src/components/SearchModal/SearchModalContainer.js
@@ -5,7 +5,7 @@ import SearchModal from './SearchModal'
 
 const TYPES = {
   ZOONIVERSE: 'ZOONIVERSE ID',
-  EXTERNAL: 'EXTERNAL ID'
+  INTERNAL: 'INTERNAL ID'
 }
 
 const initialValues = {
@@ -30,7 +30,7 @@ function SearchModalContainer() {
       initialValues={initialValues}
       onClose={onClose}
       onSubmit={onSubmit}
-      options={[ TYPES.ZOONIVERSE, TYPES.EXTERNAL ]}
+      options={[ TYPES.ZOONIVERSE, TYPES.INTERNAL ]}
       setValue={setValue}
       types={TYPES}
       value={value}

--- a/src/components/SearchModal/SearchModalContainer.js
+++ b/src/components/SearchModal/SearchModalContainer.js
@@ -23,7 +23,7 @@ function SearchModalContainer() {
   const [value, setValue] = React.useState('Select...');
   const store = React.useContext(AppContext)
   const onClose = () => store.modal.toggleModal('')
-  const onSubmit = args => store.transcriptions.searchTranscriptions(args);
+  const onSubmit = args => store.search.searchTranscriptions(args);
 
   return (
     <SearchModal

--- a/src/components/SearchModal/SearchModalContainer.js
+++ b/src/components/SearchModal/SearchModalContainer.js
@@ -11,19 +11,19 @@ const TYPES = {
 const initialValues = {
   id: null,
   type: '',
-  unreviewed: false,
+  unseen: false,
   inProgress: false,
-  readyForReview: false,
+  ready: false,
   approved: false,
   flagged: false,
-  lowConsensus: false,
+  low_consensus: false,
 }
 
 function SearchModalContainer() {
   const [value, setValue] = React.useState('Select...');
   const store = React.useContext(AppContext)
   const onClose = () => store.modal.toggleModal('')
-  const onSubmit = e => console.log(e);
+  const onSubmit = args => store.transcriptions.searchTranscriptions(args);
 
   return (
     <SearchModal

--- a/src/components/SearchModal/SearchModalContainer.spec.js
+++ b/src/components/SearchModal/SearchModalContainer.spec.js
@@ -3,13 +3,36 @@ import React from 'react'
 import SearchModalContainer from './SearchModalContainer'
 
 let wrapper;
+const searchTranscriptionsSpy = jest.fn()
+const toggleModalSpy = jest.fn()
+const contextValues = {
+  modal: {
+    toggleModal: toggleModalSpy
+  },
+  search: {
+    searchTranscriptions: searchTranscriptionsSpy
+  }
+}
 
 describe('Component > SearchModalContainer', function () {
   beforeEach(function() {
+    jest
+      .spyOn(React, 'useContext')
+      .mockImplementation((context) => contextValues)
     wrapper = shallow(<SearchModalContainer />);
   })
 
   it('should render without crashing', function () {
     expect(wrapper).toBeDefined()
+  })
+
+  it('should trigger the onClose prop', function () {
+    wrapper.props().onClose()
+    expect(toggleModalSpy).toHaveBeenCalled()
+  })
+
+  it('should trigger the onSubmit prop', function () {
+    wrapper.props().onSubmit()
+    expect(searchTranscriptionsSpy).toHaveBeenCalled()
   })
 })

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -18,6 +18,7 @@ function SubjectsPageContainer ({ history, match }) {
       store.search.reset()
     }
     setResources()
+    return () => store.modal.toggleModal('')
   }, [match, store])
 
   const onSelection = (subject) => {

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -15,6 +15,7 @@ function SubjectsPageContainer ({ history, match }) {
     const setResources = async () => {
       await store.getResources(match.params)
       await store.transcriptions.fetchTranscriptions()
+      store.search.reset()
     }
     setResources()
   }, [match, store])
@@ -43,7 +44,9 @@ function SubjectsPageContainer ({ history, match }) {
         error={store.transcriptions.error}
         onSelection={onSelection}
         resource='Subjects'
+        searching={store.search.active}
         setStep={onSetPage}
+        status={store.transcriptions.asyncState}
         state={store.transcriptions.asyncState}
         steps={steps}
       />

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -48,7 +48,6 @@ function SubjectsPageContainer ({ history, match }) {
         searching={store.search.active}
         setStep={onSetPage}
         status={store.transcriptions.asyncState}
-        state={store.transcriptions.asyncState}
         steps={steps}
       />
     </Box>

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
@@ -12,11 +12,16 @@ const getResourcesSpy = jest.fn()
 const fetchSubjectSpy = jest.fn()
 const fetchTranscriptionsSpy = jest.fn()
 const pushSpy = jest.fn()
+const resetSpy = jest.fn()
 const toggleModalSpy = jest.fn()
 const contextValues = {
   getResources: getResourcesSpy,
   modal: {
     toggleModal: toggleModalSpy
+  },
+  search: {
+    active: false,
+    reset: resetSpy
   },
   subjects: {
     fetchSubject: fetchSubjectSpy,

--- a/src/screens/SubjectsIndex/table.js
+++ b/src/screens/SubjectsIndex/table.js
@@ -316,7 +316,7 @@ const columns = [
   },
   {
     property: "id",
-    header: "External ID"
+    header: "Internal ID"
   },
   {
     property: "lastEdit",

--- a/src/screens/SubjectsIndex/table.js
+++ b/src/screens/SubjectsIndex/table.js
@@ -338,7 +338,7 @@ const columns = [
   {
     property: "flagged",
     header: "Flag",
-    render: datum => datum.flag ? <StyledFontAwesomeIcon color='tomato' icon={faCircle} /> : null
+    render: datum => datum.flagged ? <StyledFontAwesomeIcon color='tomato' icon={faCircle} /> : null
   },
   {
     property: "consensusScore",

--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -5,6 +5,7 @@ import { ClientStore } from './ClientStore'
 import { EditorStore } from './EditorStore'
 import { GroupsStore } from './GroupsStore'
 import { ImageStore } from './ImageStore'
+import { SearchStore } from './SearchStore'
 import { SubjectStore } from './SubjectStore'
 import { ProjectsStore } from './ProjectsStore'
 import { ModalStore } from './ModalStore'
@@ -18,6 +19,7 @@ const AppStore = types.model('AppStore', {
   editor: types.optional(EditorStore, () => EditorStore.create({})),
   image: types.optional(ImageStore, () => ImageStore.create({})),
   groups: types.optional(GroupsStore, () => GroupsStore.create({})),
+  search: types.optional(SearchStore, () => SearchStore.create({})),
   subjects: types.optional(SubjectStore, () => SubjectStore.create({})),
   initialized: types.optional(types.boolean, false),
   projects: types.optional(ProjectsStore, () => ProjectsStore.create({})),

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -22,6 +22,10 @@ const SearchStore = types.model('SearchStore', {
   subject_id: types.optional(types.string, ''),
   unseen: types.optional(types.boolean, false),
 }).actions(self => ({
+  clearTag: function(tag) {
+    console.log(tag);
+  },
+
   fetchTranscriptionsByFilter: flow(function * fetchTranscriptionsByFilter(args, group) {
     const transcriptions = getRoot(self).transcriptions
     transcriptions.reset()

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -1,0 +1,67 @@
+import { flow, getRoot, types } from 'mobx-state-tree'
+
+const IDS = {
+  ZOONIVERSE: 'ZOONIVERSE ID',
+  INTERNAL: 'INTERNAL ID'
+}
+
+const STATUS = {
+  unseen: 0,
+  ready: 1,
+  approved: 2,
+  in_progress: 3
+}
+
+const SearchStore = types.model('SearchStore', {
+  current: types.optional(types.string, ''),
+}).actions(self => ({
+  fetchTranscriptionsByFilter: flow(function * fetchTranscriptionsByFilter(args, group) {
+    const transcriptions = getRoot(self).transcriptions
+    transcriptions.reset()
+    let query = ''
+    const approvalFilters = ['unseen', 'in_progress', 'ready', 'approved']
+    const additionalFilters = ['flagged', 'low_consensus']
+    const activeApprovalFilters = []
+    const activeAdditionalFilters = []
+
+    Object.keys(args).forEach(key => {
+      if (args[key]) {
+        if (approvalFilters.includes(key)) activeApprovalFilters.push(key)
+        if (additionalFilters.includes(key)) activeAdditionalFilters.push(key)
+      }
+    })
+
+    if (activeApprovalFilters.length > 0) {
+      query += 'filter[status_in]='
+      activeApprovalFilters.forEach(filter => query += `${STATUS[filter]},`)
+    }
+
+    if (activeAdditionalFilters.length > 0) {
+      if (query.length > 0) query += '&'
+      activeAdditionalFilters.forEach(filter => query += `filter[${filter}_eq]=true&`)
+    }
+
+    yield transcriptions.retrieveTranscriptions(`/transcriptions?filter[group_id_eq]=${group}&${query}`)
+  }),
+
+  fetchTranscriptionsById: flow(function * fetchTranscriptionsById(type, value, group) {
+    const transcriptions = getRoot(self).transcriptions
+    transcriptions.reset()
+    type = type === IDS.ZOONIVERSE ? 'subject_id' : 'internal_id'
+    yield transcriptions.retrieveTranscriptions(`/transcriptions?filter[${type}_eq]=${value}&filter[group_id_eq]=${group}`)
+  }),
+
+  searchTranscriptions: function searchTranscriptions(args) {
+    const group = getRoot(self).groups.title
+    const idType = args.type === IDS.ZOONIVERSE || args.type === IDS.INTERNAL
+    const idValue = args.id && args.id.length > 0
+    if (idType && idValue) {
+      self.fetchTranscriptionsById(args.type, args.id, group)
+    } else {
+      self.fetchTranscriptionsByFilter(args, group)
+    }
+    getRoot(self).modal.toggleModal('')
+  },
+}))
+
+export { SearchStore }

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -5,13 +5,6 @@ const TYPES = {
   INTERNAL: 'INTERNAL ID'
 }
 
-const STATUS = {
-  unseen: 0,
-  ready: 1,
-  approved: 2,
-  in_progress: 3
-}
-
 const SearchStore = types.model('SearchStore', {
   approved: types.optional(types.boolean, false),
   flagged: types.optional(types.boolean, false),
@@ -50,8 +43,7 @@ const SearchStore = types.model('SearchStore', {
     })
 
     if (activeApprovalFilters.length > 0) {
-      const filters = activeApprovalFilters.map(filter => STATUS[filter]).join(',')
-      queries.push(`filter[status_in]=${filters}`)
+      queries.push(`filter[status_in]=${activeApprovalFilters.join(',')}`)
     }
 
     if (activeAdditionalFilters.length > 0) {

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -5,6 +5,15 @@ const TYPES = {
   INTERNAL: 'INTERNAL ID'
 }
 
+const FILTERS = {
+  APPROVED: 'approved',
+  FLAGGED: 'flagged',
+  IN_PROGRESS: 'in_progress',
+  LOW_CONSENSUS: 'low_consensus',
+  READY: 'ready',
+  UNSEEN: 'unseen'
+}
+
 const SearchStore = types.model('SearchStore', {
   approved: types.optional(types.boolean, false),
   flagged: types.optional(types.boolean, false),
@@ -30,8 +39,8 @@ const SearchStore = types.model('SearchStore', {
     const transcriptions = getRoot(self).transcriptions
     transcriptions.reset()
     let queries = []
-    const approvalFilters = ['unseen', 'in_progress', 'ready', 'approved']
-    const additionalFilters = ['flagged', 'low_consensus']
+    const approvalFilters = [FILTERS.UNSEEN, FILTERS.IN_PROGRESS, FILTERS.READY, FILTERS.APPROVED]
+    const additionalFilters = [FILTERS.FLAGGED, FILTERS.LOW_CONSENSUS]
     const activeApprovalFilters = []
     const activeAdditionalFilters = []
 
@@ -99,4 +108,4 @@ const SearchStore = types.model('SearchStore', {
   }
 }))
 
-export { TYPES, SearchStore }
+export { FILTERS, SearchStore, TYPES }

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -13,7 +13,12 @@ const STATUS = {
 }
 
 const SearchStore = types.model('SearchStore', {
-  current: types.optional(types.string, ''),
+  approved: types.optional(types.boolean, false),
+  flagged: types.optional(types.boolean, false),
+  in_progress: types.optional(types.boolean, false),
+  low_consensus: types.optional(types.boolean, false),
+  ready: types.optional(types.boolean, false),
+  unseen: types.optional(types.boolean, false),
 }).actions(self => ({
   fetchTranscriptionsByFilter: flow(function * fetchTranscriptionsByFilter(args, group) {
     const transcriptions = getRoot(self).transcriptions
@@ -28,6 +33,9 @@ const SearchStore = types.model('SearchStore', {
       if (args[key]) {
         if (approvalFilters.includes(key)) activeApprovalFilters.push(key)
         if (additionalFilters.includes(key)) activeAdditionalFilters.push(key)
+      }
+      if (self[key] !== undefined) {
+        self[key] = args[key]
       }
     })
 
@@ -51,6 +59,15 @@ const SearchStore = types.model('SearchStore', {
     yield transcriptions.retrieveTranscriptions(`/transcriptions?filter[${type}_eq]=${value}&filter[group_id_eq]=${group}`)
   }),
 
+  reset: function reset() {
+    self.approved = false
+    self.flagged = false
+    self.in_progress = false
+    self.low_consensus = false
+    self.ready = false
+    self.unseen = false
+  },
+
   searchTranscriptions: function searchTranscriptions(args) {
     const group = getRoot(self).groups.title
     const idType = args.type === IDS.ZOONIVERSE || args.type === IDS.INTERNAL
@@ -62,6 +79,11 @@ const SearchStore = types.model('SearchStore', {
     }
     getRoot(self).modal.toggleModal('')
   },
+})).views(self => ({
+  get active() {
+    return self.approved || self.flagged || self.in_progress
+    || self.low_consensus || self.ready || self.unseen
+  }
 }))
 
 export { SearchStore }

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -38,8 +38,8 @@ const SearchStore = types.model('SearchStore', {
     const activeApprovalFilters = []
     const activeAdditionalFilters = []
 
-    Object.keys(self.args).forEach(key => {
-      if (self.args[key]) {
+    Object.keys(self).forEach(key => {
+      if (self[key]) {
         if (approvalFilters.includes(key)) activeApprovalFilters.push(key)
         if (additionalFilters.includes(key)) activeAdditionalFilters.push(key)
       }
@@ -73,14 +73,11 @@ const SearchStore = types.model('SearchStore', {
   },
 
   reset: function reset() {
-    self.approved = false
-    self.flagged = false
-    self.in_progress = false
-    self.internal_id = ''
-    self.low_consensus = false
-    self.ready = false
-    self.subject_id = ''
-    self.unseen = false
+    Object.keys(self).forEach(key => {
+      const type = typeof self[key]
+      if (type === 'string') self[key] = ''
+      if (type === 'boolean') self[key] = false
+    })
   },
 
   searchTranscriptions: function searchTranscriptions(args) {
@@ -107,12 +104,6 @@ const SearchStore = types.model('SearchStore', {
     return self.approved || self.flagged || self.in_progress
     || self.low_consensus || self.ready || self.unseen
     || self.internal_id.length > 0 || self.subject_id.length > 0
-  },
-
-  get args() {
-    const args = {}
-    Object.keys(self).forEach(key => args[key] = self[key])
-    return args
   },
 
   get idQuery() {

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -23,7 +23,9 @@ const SearchStore = types.model('SearchStore', {
   unseen: types.optional(types.boolean, false),
 }).actions(self => ({
   clearTag: function(tag) {
-    console.log(tag);
+    const type = typeof self[tag];
+    if (type === 'string') self[tag] = ''
+    if (type === 'boolean') self[tag] = false
   },
 
   fetchTranscriptionsByFilter: flow(function * fetchTranscriptionsByFilter(args, group) {

--- a/src/store/SearchStore.spec.js
+++ b/src/store/SearchStore.spec.js
@@ -1,0 +1,13 @@
+import { SearchStore } from './SearchStore'
+
+let searchStore
+
+describe('SearchStore', function () {
+  beforeEach(function () {
+    searchStore = SearchStore.create()
+  })
+
+  it('should exist', function () {
+    expect(searchStore).toBeDefined()
+  })
+})

--- a/src/store/SearchStore.spec.js
+++ b/src/store/SearchStore.spec.js
@@ -23,7 +23,7 @@ describe('SearchStore', function () {
     searchStore.searchTranscriptions({ approved: true })
     expect(searchStore.approved).toBe(true)
     expect(fetchTranscriptionsSpy).toHaveBeenCalled()
-    expect(searchStore.getSearchQuery()).toBe(`&filter[status_in]=2`)
+    expect(searchStore.getSearchQuery()).toBe(`&filter[status_in]=approved`)
   })
 
   it('should searchTranscriptions and fetch by flagged', function() {;
@@ -38,7 +38,7 @@ describe('SearchStore', function () {
     expect(searchStore.low_consensus).toBe(true)
     expect(searchStore.unseen).toBe(true)
     expect(fetchTranscriptionsSpy).toHaveBeenCalled()
-    expect(searchStore.getSearchQuery()).toBe(`&filter[status_in]=0&filter[low_consensus_eq]=true`)
+    expect(searchStore.getSearchQuery()).toBe(`&filter[status_in]=unseen&filter[low_consensus_eq]=true`)
   })
 
   it('should searchTranscriptions and fetch by subject_id', function() {;

--- a/src/store/SearchStore.spec.js
+++ b/src/store/SearchStore.spec.js
@@ -1,13 +1,123 @@
-import { SearchStore } from './SearchStore'
+import { AppStore } from './AppStore'
 
 let searchStore
+const resetTranscriptionsSpy = jest.fn()
+const retrieveTranscriptionsSpy = jest.fn()
+const toggleModalSpy = jest.fn()
 
 describe('SearchStore', function () {
   beforeEach(function () {
-    searchStore = SearchStore.create()
+    const rootStore = AppStore.create({
+      groups: {
+        all: { A_TITLE: { display_name: 'A_TITLE' } },
+        current: 'A_TITLE'
+      }
+    })
+    Object.defineProperty(
+      rootStore.modal, 'toggleModal',
+      { writable: true, value: toggleModalSpy }
+    )
+    Object.defineProperty(
+      rootStore.transcriptions, 'reset',
+      { writable: true, value: resetTranscriptionsSpy }
+    )
+    Object.defineProperty(
+      rootStore.transcriptions, 'retrieveTranscriptions',
+      { writable: true, value: retrieveTranscriptionsSpy }
+    )
+    searchStore = rootStore.search
   })
+
+  afterEach(() => jest.clearAllMocks());
 
   it('should exist', function () {
     expect(searchStore).toBeDefined()
+  })
+
+  it('should searchTranscriptions and fetch by approved', function() {;
+    searchStore.searchTranscriptions({ approved: true })
+    expect(searchStore.approved).toBe(true)
+    expect(toggleModalSpy).toHaveBeenCalled()
+    expect(resetTranscriptionsSpy).toHaveBeenCalled()
+    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
+      `/transcriptions?filter[group_id_eq]=A_TITLE&filter[status_in]=2,`
+    )
+  })
+
+  it('should searchTranscriptions and fetch by flagged', function() {;
+    searchStore.searchTranscriptions({ flagged: true })
+    expect(searchStore.flagged).toBe(true)
+    expect(toggleModalSpy).toHaveBeenCalled()
+    expect(resetTranscriptionsSpy).toHaveBeenCalled()
+    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
+      `/transcriptions?filter[group_id_eq]=A_TITLE&filter[flagged_eq]=true&`
+    )
+  })
+
+  it('should searchTranscriptions by an approval and additional filter', function () {
+    searchStore.searchTranscriptions({ low_consensus: true, unseen: true })
+    expect(searchStore.low_consensus).toBe(true)
+    expect(searchStore.unseen).toBe(true)
+    expect(toggleModalSpy).toHaveBeenCalled()
+    expect(resetTranscriptionsSpy).toHaveBeenCalled()
+    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
+      `/transcriptions?filter[group_id_eq]=A_TITLE&filter[status_in]=0,&filter[low_consensus_eq]=true&`
+    )
+  })
+
+  it('should searchTranscriptions and fetch by subject_id', function() {;
+    searchStore.searchTranscriptions({ id: '1', type: 'ZOONIVERSE ID' })
+    expect(searchStore.id).toBe('1')
+    expect(searchStore.type).toBe('ZOONIVERSE ID')
+    expect(toggleModalSpy).toHaveBeenCalled()
+    expect(resetTranscriptionsSpy).toHaveBeenCalled()
+    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
+      `/transcriptions?filter[subject_id_eq]=1&filter[group_id_eq]=A_TITLE`
+    )
+  })
+
+  it('should searchTranscriptions and fetch by internal_id', function() {;
+    searchStore.searchTranscriptions({ id: '1', type: 'INTERNAL ID' })
+    expect(searchStore.id).toBe('1')
+    expect(searchStore.type).toBe('INTERNAL ID')
+    expect(toggleModalSpy).toHaveBeenCalled()
+    expect(resetTranscriptionsSpy).toHaveBeenCalled()
+    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
+      `/transcriptions?filter[internal_id_eq]=1&filter[group_id_eq]=A_TITLE`
+    )
+  })
+
+  it('should reset args', function() {
+    searchStore.searchTranscriptions({ approved: true })
+    searchStore.reset()
+    expect(searchStore.approved).toBe(false)
+  })
+
+  it('should recognize an active search', function() {
+    searchStore.searchTranscriptions({ approved: true })
+    expect(searchStore.active).toBe(true)
+  })
+
+  it('should recognize an inactive search', function() {
+    expect(searchStore.active).toBe(false)
+  })
+
+  it('should clear id tags', function() {
+    searchStore.searchTranscriptions({ id: '1', type: 'ZOONIVERSE ID' })
+    searchStore.clearIdTags()
+    expect(searchStore.id).toBe('')
+    expect(searchStore.type).toBe('')
+  })
+
+  it('should clear a tag', function() {
+    searchStore.searchTranscriptions({ approved: true })
+    searchStore.clearTag('approved')
+    expect(searchStore.approved).toBe(false)
+  })
+
+  it('should ignore an invalid argument', function() {
+    const initialStore = Object.assign({}, searchStore)
+    searchStore.searchTranscriptions({ foo: 'bar' })
+    expect(initialStore).toStrictEqual(searchStore)
   })
 })

--- a/src/store/SearchStore.spec.js
+++ b/src/store/SearchStore.spec.js
@@ -1,29 +1,14 @@
 import { AppStore } from './AppStore'
 
 let searchStore
-const resetTranscriptionsSpy = jest.fn()
-const retrieveTranscriptionsSpy = jest.fn()
-const toggleModalSpy = jest.fn()
+const fetchTranscriptionsSpy = jest.fn()
 
 describe('SearchStore', function () {
   beforeEach(function () {
-    const rootStore = AppStore.create({
-      groups: {
-        all: { A_TITLE: { display_name: 'A_TITLE' } },
-        current: 'A_TITLE'
-      }
-    })
+    const rootStore = AppStore.create()
     Object.defineProperty(
-      rootStore.modal, 'toggleModal',
-      { writable: true, value: toggleModalSpy }
-    )
-    Object.defineProperty(
-      rootStore.transcriptions, 'reset',
-      { writable: true, value: resetTranscriptionsSpy }
-    )
-    Object.defineProperty(
-      rootStore.transcriptions, 'retrieveTranscriptions',
-      { writable: true, value: retrieveTranscriptionsSpy }
+      rootStore.transcriptions, 'fetchTranscriptions',
+      { writable: true, value: fetchTranscriptionsSpy }
     )
     searchStore = rootStore.search
   })
@@ -37,54 +22,39 @@ describe('SearchStore', function () {
   it('should searchTranscriptions and fetch by approved', function() {;
     searchStore.searchTranscriptions({ approved: true })
     expect(searchStore.approved).toBe(true)
-    expect(toggleModalSpy).toHaveBeenCalled()
-    expect(resetTranscriptionsSpy).toHaveBeenCalled()
-    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
-      `/transcriptions?filter[group_id_eq]=A_TITLE&filter[status_in]=2,`
-    )
+    expect(fetchTranscriptionsSpy).toHaveBeenCalled()
+    expect(searchStore.getSearchQuery()).toBe(`&filter[status_in]=2`)
   })
 
   it('should searchTranscriptions and fetch by flagged', function() {;
     searchStore.searchTranscriptions({ flagged: true })
     expect(searchStore.flagged).toBe(true)
-    expect(toggleModalSpy).toHaveBeenCalled()
-    expect(resetTranscriptionsSpy).toHaveBeenCalled()
-    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
-      `/transcriptions?filter[group_id_eq]=A_TITLE&filter[flagged_eq]=true&`
-    )
+    expect(fetchTranscriptionsSpy).toHaveBeenCalled()
+    expect(searchStore.getSearchQuery()).toBe(`&filter[flagged_eq]=true`)
   })
 
   it('should searchTranscriptions by an approval and additional filter', function () {
     searchStore.searchTranscriptions({ low_consensus: true, unseen: true })
     expect(searchStore.low_consensus).toBe(true)
     expect(searchStore.unseen).toBe(true)
-    expect(toggleModalSpy).toHaveBeenCalled()
-    expect(resetTranscriptionsSpy).toHaveBeenCalled()
-    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
-      `/transcriptions?filter[group_id_eq]=A_TITLE&filter[status_in]=0,&filter[low_consensus_eq]=true&`
-    )
+    expect(fetchTranscriptionsSpy).toHaveBeenCalled()
+    expect(searchStore.getSearchQuery()).toBe(`&filter[status_in]=0&filter[low_consensus_eq]=true`)
   })
 
   it('should searchTranscriptions and fetch by subject_id', function() {;
     searchStore.searchTranscriptions({ id: '1', type: 'ZOONIVERSE ID' })
     expect(searchStore.id).toBe('1')
     expect(searchStore.type).toBe('ZOONIVERSE ID')
-    expect(toggleModalSpy).toHaveBeenCalled()
-    expect(resetTranscriptionsSpy).toHaveBeenCalled()
-    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
-      `/transcriptions?filter[subject_id_eq]=1&filter[group_id_eq]=A_TITLE`
-    )
+    expect(fetchTranscriptionsSpy).toHaveBeenCalled()
+    expect(searchStore.getSearchQuery()).toBe(`&filter[subject_id_eq]=1`)
   })
 
   it('should searchTranscriptions and fetch by internal_id', function() {;
     searchStore.searchTranscriptions({ id: '1', type: 'INTERNAL ID' })
     expect(searchStore.id).toBe('1')
     expect(searchStore.type).toBe('INTERNAL ID')
-    expect(toggleModalSpy).toHaveBeenCalled()
-    expect(resetTranscriptionsSpy).toHaveBeenCalled()
-    expect(retrieveTranscriptionsSpy).toHaveBeenCalledWith(
-      `/transcriptions?filter[internal_id_eq]=1&filter[group_id_eq]=A_TITLE`
-    )
+    expect(fetchTranscriptionsSpy).toHaveBeenCalled()
+    expect(searchStore.getSearchQuery()).toBe(`&filter[internal_id_eq]=1`)
   })
 
   it('should reset args', function() {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -6,6 +6,13 @@ const IDS = {
   EXTERNAL: 'EXTERNAL ID'
 }
 
+const STATUS = {
+  unseen: 0,
+  ready: 1,
+  approved: 2,
+  in_progress: 3
+}
+
 const Transcription = types.model('Transcription', {
   id: types.identifier,
   flaggedid: types.optional(types.boolean, false),
@@ -67,9 +74,78 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     }
   }),
 
+  fetchTranscriptionsByFilter: flow(function * fetchTranscriptionsByFilter(args, group) {
+    let query = ''
+    const approvalFilters = ['unseen', 'in_progress', 'ready', 'approved']
+    const additionalFilters = ['flagged', 'low_consensus']
+    const activeApprovalFilters = []
+    const activeAdditionalFilters = []
+
+    Object.keys(args).forEach(key => {
+      if (args[key]) {
+        if (approvalFilters.includes(key)) activeApprovalFilters.push(key)
+        if (additionalFilters.includes(key)) activeAdditionalFilters.push(key)
+      }
+    })
+
+    if (activeApprovalFilters.length > 0) {
+      query += 'filter[status_in]='
+      activeApprovalFilters.forEach(filter => query += `${STATUS[filter]},`)
+    }
+
+    if (activeAdditionalFilters.length > 0) {
+      if (query.length > 0) query += '&'
+      activeAdditionalFilters.forEach(filter => query += `filter[${filter}_eq]=true&`)
+    }
+
+    const client = getRoot(self).client.tove
+    const modal = getRoot(self).modal
+    try {
+      const response = yield client.get(`/transcriptions?filter[group_id_eq]=${group}&${query}`)
+      const resources = JSON.parse(response.body)
+      resources.data.forEach(transcription => self.all.put(self.createTranscription(transcription)))
+      self.asyncState = ASYNC_STATES.READY
+    } catch (error) {
+      console.warn(error);
+      self.error = error.message
+      self.asyncState = ASYNC_STATES.ERROR
+    }
+    modal.toggleModal('')
+  }),
+
+  fetchTranscriptionsById: flow(function * fetchTranscriptionsById(type, value, group) {
+    type = type === IDS.ZOONIVERSE ? 'subject_id' : 'internal_id'
+    const client = getRoot(self).client.tove
+    const modal = getRoot(self).modal
+    try {
+      const response = yield client.get(`/transcriptions?filter[${type}_eq]=${value}&filter[group_id_eq]=${group}`)
+      const resources = JSON.parse(response.body)
+      resources.data.forEach(transcription => self.all.put(self.createTranscription(transcription)))
+      self.asyncState = ASYNC_STATES.READY
+    } catch (error) {
+      console.warn(error);
+      self.error = error.message
+      self.asyncState = ASYNC_STATES.ERROR
+    }
+    modal.toggleModal('')
+  }),
+
   reset: () => {
     self.selectTranscription(null)
     self.all.clear()
+  },
+
+  searchTranscriptions: function searchTranscriptions(args) {
+    const group = getRoot(self).groups.title
+    const idType = args.type === IDS.ZOONIVERSE || args.type === IDS.EXTERNAL
+    const idValue = args.id && args.id.length > 0
+    if (idType && idValue) {
+      self.reset()
+      self.fetchTranscriptionsById(args.type, args.id, group)
+    } else {
+      self.reset()
+      self.fetchTranscriptionsByFilter(args, group)
+    }
   },
 
   selectTranscription: flow(function * selectTranscription(id = null) {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -3,7 +3,7 @@ import ASYNC_STATES from 'helpers/asyncStates'
 
 const IDS = {
   ZOONIVERSE: 'ZOONIVERSE ID',
-  EXTERNAL: 'EXTERNAL ID'
+  INTERNAL: 'INTERNAL ID'
 }
 
 const STATUS = {
@@ -117,7 +117,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   searchTranscriptions: function searchTranscriptions(args) {
     const group = getRoot(self).groups.title
-    const idType = args.type === IDS.ZOONIVERSE || args.type === IDS.EXTERNAL
+    const idType = args.type === IDS.ZOONIVERSE || args.type === IDS.INTERNAL
     const idValue = args.id && args.id.length > 0
     if (idType && idValue) {
       self.reset()

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -3,7 +3,7 @@ import ASYNC_STATES from 'helpers/asyncStates'
 
 const Transcription = types.model('Transcription', {
   id: types.identifier,
-  flaggedid: types.optional(types.boolean, false),
+  flagged: types.optional(types.boolean, false),
   group_id: types.optional(types.string, ''),
   status: types.optional(types.string, ''),
   text: types.optional(types.frozen(), {}),

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -1,6 +1,11 @@
 import { flow, getRoot, types } from 'mobx-state-tree'
 import ASYNC_STATES from 'helpers/asyncStates'
 
+const IDS = {
+  ZOONIVERSE: 'ZOONIVERSE ID',
+  EXTERNAL: 'EXTERNAL ID'
+}
+
 const Transcription = types.model('Transcription', {
   id: types.identifier,
   flaggedid: types.optional(types.boolean, false),


### PR DESCRIPTION
This is WIP because we're still waiting on a couple items before this is ready.

Closes #21 

1) Waiting for #68 to merge because I'll have to keep track of the current query when paginating. What if somebody has an active search filter? They'll want to retain that filter when paginating.
2) There are several items that aren't yet filterable on the Tove end (`internal_id`, `low_consensus_score`, filtering by status string instead of enum integer). 