### PR TITLE
Allow SignOut function to Reset User

### DIFF
--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -37,6 +37,7 @@ const AuthStore = types.model('AuthStore', {
     } catch (error) {
       console.warn(error);
     }
+    self.user = null
     history.push('/')
   })
 }))

--- a/src/store/AuthStore.spec.js
+++ b/src/store/AuthStore.spec.js
@@ -47,16 +47,18 @@ describe('AuthStore', function () {
 
   describe('logout function success', function () {
     let signOutSpy
+    const user = { id: '1' }
 
     beforeAll(function () {
       signOutSpy = jest
         .spyOn(auth, 'signOut')
         .mockImplementation(() => Promise.resolve())
-      authStore = AuthStore.create()
+      authStore = AuthStore.create({ user })
     })
 
     it('should call the sign out function', async function () {
       await authStore.logout()
+      expect(authStore.user).toBe(null)
       expect(signOutSpy).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
In making some changes to #67, I realized the logout function wasn't actually resetting forgetting the user within the app. 