### PR TITLE
Fetch Single Transcription Bug

### DIFF
--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -2,11 +2,10 @@ import { flow, getRoot, types } from 'mobx-state-tree'
 import ASYNC_STATES from 'helpers/asyncStates'
 
 const Transcription = types.model('Transcription', {
-  id: types.optional(types.string, ''),
+  id: types.identifier,
   flaggedid: types.optional(types.boolean, false),
   group_id: types.optional(types.string, ''),
   status: types.optional(types.string, ''),
-  subject_id: types.identifier,
   text: types.optional(types.frozen(), {}),
 })
 
@@ -24,7 +23,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
       flagged: transcription.attributes.flagged,
       group_id: transcription.attributes.group_id,
       status: transcription.attributes.status,
-      subject_id: transcription.attributes.subject_id.toString(),
       text: transcription.attributes.text
     })
   },
@@ -34,11 +32,10 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     self.asyncState = ASYNC_STATES.LOADING
     const client = getRoot(self).client.tove
     try {
-      const response = yield client.get(`/transcriptions?filter[subject_id_eq]=${id}`)
+      const response = yield client.get(`/transcriptions/${id}`)
       const resource = JSON.parse(response.body)
       self.asyncState = ASYNC_STATES.READY
-      // TODO: Line below will have to change to resource.data when Tove begins delivering a single transcription
-      return self.createTranscription(resource.data[0])
+      return self.createTranscription(resource.data)
     } catch (error) {
       console.warn(error);
       self.error = error.message
@@ -98,7 +95,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   },
 
   get title () {
-    return (self.current && self.current.subject_id) || ''
+    return (self.current && self.current.id) || ''
   }
 }))
 

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -6,12 +6,26 @@ let transcriptionsStore
 let rootStore
 let simpleTranscription = TranscriptionFactory.build({ status: 'approved' })
 
-let toveStub = {
+let fetchTranscriptionsStub = {
   get: () => Promise.resolve(
     {
       body: JSON.stringify(
         {
           data: [TranscriptionFactory.build(), TranscriptionFactory.build({ id: '2', attributes: { status: 'approved', subject_id: '2' }})],
+          meta: {
+            pagination: { last: 1 }
+          }
+        })
+    }
+  )
+}
+
+let fetchTranscriptionStub = {
+  get: () => Promise.resolve(
+    {
+      body: JSON.stringify(
+        {
+          data: TranscriptionFactory.build(),
           meta: {
             pagination: { last: 1 }
           }
@@ -25,10 +39,10 @@ let failedToveStub = {
 }
 
 describe('TranscriptionsStore', function () {
-  describe('success state', function () {
+  describe('success state fetching multiple transcriptions', function () {
     beforeEach(function () {
       rootStore = AppStore.create({
-        client: { tove: toveStub },
+        client: { tove: fetchTranscriptionsStub },
         groups: {
           current: {
             display_name: 'GROUP_1'
@@ -60,7 +74,19 @@ describe('TranscriptionsStore', function () {
       expect(transcriptionsStore.current).toEqual(transcription)
     })
 
+  })
+
+  describe('success state fetching single transcription', function () {
     it('should fetch a single transcription', async function () {
+      rootStore = AppStore.create({
+        client: { tove: fetchTranscriptionStub },
+        groups: {
+          current: {
+            display_name: 'GROUP_1'
+          }
+        }
+      })
+      transcriptionsStore = rootStore.transcriptions
       const returnValue = await transcriptionsStore.fetchTranscription('1')
       expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.READY)
       expect(returnValue).toBeDefined()


### PR DESCRIPTION
Fixes a TODO from when TOVE did not have a one to one relationship between transcription ids and Panoptes subjects. Because of this, the app originally looked for transcriptions associated with a particular subject. However, with the change, a `/transcriptions/id` route now exists, and Alice can hit that endpoint and expect to receive one object instead of an array.

Merging this now as the app is currently breaking without the fix.