### PR TITLE
Avoid Two hour timeout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,8 @@ import { Grommet } from 'grommet'
 import AppContext from 'store'
 import makeInspectable from 'mobx-devtools-mst'
 import { observer } from 'mobx-react'
+import apiClient from 'panoptes-client/lib/api-client';
+import auth from 'panoptes-client/lib/auth';
 import ScrollToTop from 'helpers/scrollToTop'
 import history from './history'
 import './App.css'
@@ -25,12 +27,19 @@ import {
   EDIT_PATH
 } from 'paths'
 
+function checkToken(store) {
+  return auth.checkBearerToken().then((token) => {
+    store.client.setBearerToken(token)
+  })
+}
+
 function App() {
   const store = React.useContext(AppContext)
   makeInspectable(store)
 
   React.useEffect(() => {
     store.initialize()
+    apiClient.beforeEveryRequest = () => checkToken(store)
   }, [store])
 
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,16 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
+import apiClient from 'panoptes-client/lib/api-client';
+import { act } from 'react-dom/test-utils'
 import { App } from './App'
 
 let wrapper
+const setBearerTokenSpy = jest.fn()
+
 const contextValues = {
+  client: {
+    setBearerToken: setBearerTokenSpy
+  },
   initialize: () => {},
   initialized: true
 }
@@ -15,11 +22,25 @@ describe('App', function () {
     expect(wrapper).toBeDefined()
   })
 
-  it('should render nothing when not initialized', function () {
-    const revisedContext = Object.assign({}, contextValues)
-    revisedContext.initialized = false
-    jest.spyOn(React, 'useContext').mockImplementation((context) => revisedContext)
-    wrapper = shallow(<App />);
-    expect(wrapper.getElement()).toBe(null)
+  describe('when not initialized', function () {
+    beforeEach(function() {
+      const revisedContext = Object.assign({}, contextValues)
+      revisedContext.initialized = false
+      jest.spyOn(React, 'useContext').mockImplementation((context) => revisedContext)
+    })
+
+    it('should render nothing when not initialized', function () {
+      wrapper = shallow(<App />);
+      expect(wrapper.getElement()).toBe(null)
+    })
+
+    it('should check the token before each request', async function () {
+      wrapper = mount(<App />);
+      await act(async () => {
+        apiClient.beforeEveryRequest()
+        wrapper.update();;
+      });
+      expect(setBearerTokenSpy).toHaveBeenCalled()
+    })
   })
 })

--- a/src/helpers/mockJWT.js
+++ b/src/helpers/mockJWT.js
@@ -1,0 +1,3 @@
+export default function mockJWT(mockClient) {
+  return Object.assign({ jwt: () => {} }, mockClient)
+}

--- a/src/helpers/mockJWT.spec.js
+++ b/src/helpers/mockJWT.spec.js
@@ -1,0 +1,16 @@
+import mockJWT from './mockJWT'
+
+describe('Helper > mockJWT', function () {
+  describe('default', function () {
+    it('should return a mocked object', function () {
+      const result = mockJWT()
+      expect(result).toHaveProperty('jwt')
+    })
+  })
+
+  it('should return a merged mocked object', function () {
+    const client = { get: () => {} }
+    const result = mockJWT(client)
+    expect(result).toHaveProperty('jwt')
+  })
+})

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -73,9 +73,12 @@ const ClientStore = types.model('ClientStore', {
   setBearerToken: (token) => {
     // If Token is null, we need to remove jwt tokens
     // If token is a string with a length, we need to set tokens
-    if (token === null || token.length) {
+    if (token) {
       self.tove.jwt(token)
       self.toveZip.jwt(token)
+    } else {
+      self.tove.jwt()
+      self.toveZip.jwt()
     }
   }
 }))

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -64,10 +64,10 @@ const ClientStore = types.model('ClientStore', {
     })
   }),
 
-  patch: flow(function* get (request) {
+  patch: flow(function* get (request, body) {
     return yield auth.checkBearerToken().then((token) => {
       self.setBearerToken(token)
-      return self.tove.patch(request)
+      return self.tove.patch(request, body)
     })
   }),
 

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -64,6 +64,13 @@ const ClientStore = types.model('ClientStore', {
     })
   }),
 
+  patch: flow(function* get (request) {
+    return yield auth.checkBearerToken().then((token) => {
+      self.setBearerToken(token)
+      return self.tove.patch(request)
+    })
+  }),
+
   setBearerToken: (token) => {
     if (token !== self.bearerToken) {
       self.bearerToken = token

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -6,7 +6,6 @@ import auth from 'panoptes-client/lib/auth';
 
 const ClientStore = types.model('ClientStore', {
   aggregator: types.optional(types.frozen({}), null),
-  bearerToken: types.optional(types.string, ''),
   tove: types.optional(types.frozen({}), null),
   toveZip: types.optional(types.frozen({}), null)
 }).actions(self => ({
@@ -72,8 +71,7 @@ const ClientStore = types.model('ClientStore', {
   }),
 
   setBearerToken: (token) => {
-    if (token !== self.bearerToken) {
-      self.bearerToken = token
+    if (!!token) {
       self.tove.jwt(token)
       self.toveZip.jwt(token)
     }

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -2,6 +2,7 @@ import { flow, getRoot, types } from 'mobx-state-tree'
 import Frisbee from 'frisbee'
 import { config } from 'config'
 import download from 'downloadjs'
+import auth from 'panoptes-client/lib/auth';
 
 const ClientStore = types.model('ClientStore', {
   aggregator: types.optional(types.frozen({}), null),
@@ -57,12 +58,18 @@ const ClientStore = types.model('ClientStore', {
   }),
 
   get: flow(function* get (request) {
-    return yield self.tove.get(request)
+    return yield auth.checkBearerToken().then((token) => {
+      self.setBearerToken(token)
+      return self.tove.get(request)
+    })
   }),
 
   setBearerToken: (token) => {
-    self.tove.jwt(token)
-    self.toveZip.jwt(token)
+    if (token !== self.bearerToken) {
+      self.bearerToken = token
+      self.tove.jwt(token)
+      self.toveZip.jwt(token)
+    }
   }
 }))
 

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -71,7 +71,9 @@ const ClientStore = types.model('ClientStore', {
   }),
 
   setBearerToken: (token) => {
-    if (!!token) {
+    // If Token is null, we need to remove jwt tokens
+    // If token is a string with a length, we need to set tokens
+    if (token === null || token.length) {
       self.tove.jwt(token)
       self.toveZip.jwt(token)
     }

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -56,6 +56,10 @@ const ClientStore = types.model('ClientStore', {
       }
   }),
 
+  get: flow(function* get (request) {
+    return yield self.tove.get(request)
+  }),
+
   setBearerToken: (token) => {
     self.tove.jwt(token)
     self.toveZip.jwt(token)

--- a/src/store/ProjectsStore.js
+++ b/src/store/ProjectsStore.js
@@ -49,7 +49,7 @@ const ProjectsStore = types.model('ProjectsStore', {
 
   getProjects: flow (function * getProjects() {
     self.asyncState = ASYNC_STATES.LOADING
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     try {
       const response = yield client.get('/projects')
       const resources = JSON.parse(response.body)

--- a/src/store/ProjectsStore.spec.js
+++ b/src/store/ProjectsStore.spec.js
@@ -1,6 +1,7 @@
 import apiClient from 'panoptes-client/lib/api-client.js';
 import ASYNC_STATES from 'helpers/asyncStates'
 import { when } from 'jest-when'
+import mockJWT from 'helpers/mockJWT'
 import { AppStore } from './AppStore'
 import ProjectFactory from './factories/project'
 
@@ -46,7 +47,7 @@ const rootStore = AppStore.create({
   auth: {
     user: { id: '1' }
   },
-  client: { tove: toveStub }
+  client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
 })
 
 describe('ProjectsStore', function () {
@@ -197,7 +198,7 @@ describe('Default role', function () {
       auth: {
         user: { id: '1' }
       },
-      client: { tove: toveStub }
+      client: { tove: mockJWT(toveStub), toveZip: mockJWT() }
     })
     projectsStore = rootStore.projects
     await projectsStore.getProjects()

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -98,7 +98,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   const checkIfLocked = flow(function * checkIfLocked() {
-    const client = getRoot(self).client
+    const { client } = getRoot(self)
     const response = yield client.get(`/transcriptions/${self.title}`)
     const resource = JSON.parse(response.body)
     const lockedBy = resource.data.attributes.locked_by

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -271,7 +271,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   })
 
   const patchTranscription = flow(function * patchTranscription(query) {
-    const { client } = getRoot(self)©
+    const { client } = getRoot(self)
     let lastModified
     try {
       yield client.patch(`/transcriptions/${self.current.id}`, { body: query, headers: { 'If-Unmodified-Since': self.current.last_modified } }).then(response => {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -271,7 +271,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   })
 
   const patchTranscription = flow(function * patchTranscription(query) {
-    const client = getRoot(self).client
+    const { client } = getRoot(self)©
     let lastModified
     try {
       yield client.patch(`/transcriptions/${self.current.id}`, { body: query, headers: { 'If-Unmodified-Since': self.current.last_modified } }).then(response => {
@@ -337,7 +337,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   const retrieveTranscriptions = flow(function * retrieveTranscriptions(query) {
-    const client = getRoot(self).client
+    const { client } = getRoot(self)
     undoManager.withoutUndo(() => self.asyncState = ASYNC_STATES.LOADING)
     try {
       const response = yield client.get(query)
@@ -387,7 +387,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   const selectTranscription = flow(function * selectTranscription(id = null) {
     if (!id) return undefined
     undoManager.withoutUndo(() => self.asyncState = ASYNC_STATES.LOADING)
-    const client = getRoot(self).client
+    const { client } = getRoot(self)
     try {
       const response = yield client.get(`/transcriptions/${id}`)
       const lastModified = getLastModified(response)
@@ -459,7 +459,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   const unlockTranscription = flow(function * unlockTranscription() {
-    const client = getRoot(self).client
+    const { client } = getRoot(self)
     yield client.patch(`/transcriptions/${self.current.id}/unlock`, { headers: { 'If-Unmodified-Since': self.current.last_modified } })
   })
 

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -98,7 +98,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   const checkIfLocked = flow(function * checkIfLocked() {
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     const response = yield client.get(`/transcriptions/${self.title}`)
     const resource = JSON.parse(response.body)
     const lockedBy = resource.data.attributes.locked_by
@@ -271,7 +271,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   })
 
   const patchTranscription = flow(function * patchTranscription(query) {
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     let lastModified
     try {
       yield client.patch(`/transcriptions/${self.current.id}`, { body: query, headers: { 'If-Unmodified-Since': self.current.last_modified } }).then(response => {
@@ -337,7 +337,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   const retrieveTranscriptions = flow(function * retrieveTranscriptions(query) {
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     undoManager.withoutUndo(() => self.asyncState = ASYNC_STATES.LOADING)
     try {
       const response = yield client.get(query)
@@ -387,7 +387,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   const selectTranscription = flow(function * selectTranscription(id = null) {
     if (!id) return undefined
     undoManager.withoutUndo(() => self.asyncState = ASYNC_STATES.LOADING)
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     try {
       const response = yield client.get(`/transcriptions/${id}`)
       const lastModified = getLastModified(response)
@@ -459,7 +459,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   const unlockTranscription = flow(function * unlockTranscription() {
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     yield client.patch(`/transcriptions/${self.current.id}/unlock`, { headers: { 'If-Unmodified-Since': self.current.last_modified } })
   })
 

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -2,6 +2,7 @@ import ASYNC_STATES from 'helpers/asyncStates'
 import * as graphQl from 'graphql-request'
 import apiClient from 'panoptes-client/lib/api-client.js';
 import { mockExtract } from 'helpers/parseTranscriptionData.spec'
+import mockJWT from 'helpers/mockJWT'
 import { AppStore } from './AppStore'
 import TranscriptionFactory from './factories/transcription'
 
@@ -139,7 +140,7 @@ describe('TranscriptionsStore', function () {
     describe('success state', function () {
       beforeEach(async function () {
         rootStore = AppStore.create({
-          client: { tove: multipleTranscriptionsStub },
+          client: { tove: mockJWT(multipleTranscriptionsStub), toveZip: mockJWT() },
           groups: {
             current: {
               display_name: 'GROUP_1'
@@ -188,7 +189,7 @@ describe('TranscriptionsStore', function () {
 
     describe('failure state', function () {
       it('should register an error', async function () {
-        rootStore = AppStore.create({ client: { tove: failedToveStub }})
+        rootStore = AppStore.create({ client: { tove: mockJWT(failedToveStub), toveZip: mockJWT() }})
         transcriptionsStore = rootStore.transcriptions
         await transcriptionsStore.retrieveTranscriptions()
         expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
@@ -214,7 +215,8 @@ describe('TranscriptionsStore', function () {
           auth: { user: { display_name: 'A_USER' } },
           client: {
             aggregator: aggregatorStub,
-            tove: singleTranscriptionStub
+            tove: mockJWT(singleTranscriptionStub),
+            toveZip: mockJWT()
           },
           groups: {
             current: {
@@ -330,7 +332,7 @@ describe('TranscriptionsStore', function () {
       it('should return true if the transcription is lockedByCurrentUser', async function () {
         const unlockableStore = AppStore.create({
           auth: { user: { display_name: 'A_USER' } },
-          client: { tove: unlockedTranscriptionStub },
+          client: { tove: mockJWT(unlockedTranscriptionStub), toveZip: mockJWT() },
           groups: {
             current: { display_name: 'GROUP_1' }
           },
@@ -437,7 +439,7 @@ describe('TranscriptionsStore', function () {
 
     describe('failure state', function () {
       it('should register an error on selecting', async function () {
-        rootStore = AppStore.create({ client: { tove: failedToveStub }})
+        rootStore = AppStore.create({ client: { tove: mockJWT(failedToveStub), toveZip: mockJWT() }})
         transcriptionsStore = rootStore.transcriptions
         await transcriptionsStore.selectTranscription(1)
         expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
@@ -446,7 +448,7 @@ describe('TranscriptionsStore', function () {
 
       it('should register an error on patching', async function () {
         rootStore = AppStore.create({
-          client: { tove: failedTovePatch },
+          client: { tove: mockJWT(failedTovePatch), toveZip: mockJWT() },
           workflows: {
             all: { 1: { id: '1' } },
             current: '1'
@@ -461,7 +463,7 @@ describe('TranscriptionsStore', function () {
 
       it('should register an error on patching if response not ok', async function () {
         rootStore = AppStore.create({
-          client: { tove: failedTovePatchNotOk },
+          client: { tove: mockJWT(failedTovePatchNotOk), toveZip: mockJWT() },
           workflows: {
             all: { 1: { id: '1' } },
             current: '1'

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -278,8 +278,8 @@ describe('TranscriptionsStore', function () {
         expect(transcriptionsStore.current.last_modified).toBe('Mon, June 31, 2020')
       })
 
-      it('should update the flagged attribute', function () {
-        transcriptionsStore.setTextObject([mockReduction])
+      it('should update the flagged attribute', async function () {
+        await transcriptionsStore.setTextObject([mockReduction])
         expect(transcriptionsStore.current.flagged).toBe(false)
         transcriptionsStore.checkForFlagUpdate()
         expect(patchToveSpy).toHaveBeenCalled()
@@ -376,11 +376,11 @@ describe('TranscriptionsStore', function () {
           expect(patchToveSpy).not.toHaveBeenCalled()
         })
 
-        it('should delete a line', function () {
+        it('should delete a line', async function () {
           transcriptionsStore.setActiveTranscription(0)
           const current = transcriptionsStore.current.text.get('frame0')
           expect(current.length).toBe(2)
-          transcriptionsStore.deleteCurrentLine()
+          await transcriptionsStore.deleteCurrentLine()
           expect(current.length).toBe(1)
           expect(patchToveSpy).toHaveBeenCalled()
         })
@@ -394,8 +394,8 @@ describe('TranscriptionsStore', function () {
       })
 
       describe('and making a change', function () {
-        it('should undo the previous action', function () {
-          transcriptionsStore.setTextObject([mockReduction])
+        it('should undo the previous action', async function () {
+          await transcriptionsStore.setTextObject([mockReduction])
           transcriptionsStore.undo()
           expect(patchToveSpy).toHaveBeenCalled()
         })

--- a/src/store/WorkflowsStore.js
+++ b/src/store/WorkflowsStore.js
@@ -31,7 +31,7 @@ const WorkflowsStore = types.model('WorkflowsStore', {
   fetchWorkflows: flow (function * fetchWorkflows(id, page = 0) {
     self.page = page
     self.asyncState = ASYNC_STATES.LOADING
-    const client = getRoot(self).client
+    const { client } = getRoot(self)
     try {
       const response = yield client.get(`/workflows?filter[project_id_eq]=${id}&page[number]=${self.page+1}`)
       const resources = JSON.parse(response.body)

--- a/src/store/WorkflowsStore.js
+++ b/src/store/WorkflowsStore.js
@@ -48,7 +48,7 @@ const WorkflowsStore = types.model('WorkflowsStore', {
   getWorkflow: flow (function * getWorkflow(id) {
     if (!id) return undefined
     self.asyncState = ASYNC_STATES.LOADING
-    const client = getRoot(self).client
+    const { client } = getRoot(self)
     try {
       const response = yield client.get(`/workflows/${id}`)
       const resource = JSON.parse(response.body)

--- a/src/store/WorkflowsStore.js
+++ b/src/store/WorkflowsStore.js
@@ -31,7 +31,7 @@ const WorkflowsStore = types.model('WorkflowsStore', {
   fetchWorkflows: flow (function * fetchWorkflows(id, page = 0) {
     self.page = page
     self.asyncState = ASYNC_STATES.LOADING
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     try {
       const response = yield client.get(`/workflows?filter[project_id_eq]=${id}&page[number]=${self.page+1}`)
       const resources = JSON.parse(response.body)
@@ -48,7 +48,7 @@ const WorkflowsStore = types.model('WorkflowsStore', {
   getWorkflow: flow (function * getWorkflow(id) {
     if (!id) return undefined
     self.asyncState = ASYNC_STATES.LOADING
-    const client = getRoot(self).client.tove
+    const client = getRoot(self).client
     try {
       const response = yield client.get(`/workflows/${id}`)
       const resource = JSON.parse(response.body)

--- a/src/store/WorkflowsStore.spec.js
+++ b/src/store/WorkflowsStore.spec.js
@@ -1,4 +1,5 @@
 import ASYNC_STATES from 'helpers/asyncStates'
+import mockJWT from 'helpers/mockJWT'
 import { AppStore } from './AppStore'
 import WorkflowFactory from './factories/workflow'
 
@@ -43,7 +44,7 @@ describe('WorkflowsStore', function () {
   describe('success state', function () {
     beforeEach(function () {
       rootStore = AppStore.create({
-        client: { tove: toveStubArray }
+        client: { tove: mockJWT(toveStubArray), toveZip: mockJWT() }
       })
       workflowsStore = rootStore.workflows
     })
@@ -76,7 +77,7 @@ describe('WorkflowsStore', function () {
     })
 
     it('should fetch a single workflow', async function () {
-      rootStore = AppStore.create({ client: { tove: toveStub }})
+      rootStore = AppStore.create({ client: { tove: mockJWT(toveStub), toveZip: mockJWT() }})
       workflowsStore = rootStore.workflows
       const returnValue = await workflowsStore.getWorkflow('1')
       expect(returnValue).toBeDefined()
@@ -86,7 +87,7 @@ describe('WorkflowsStore', function () {
 
   describe('failure state', function () {
     beforeEach(function () {
-      rootStore = AppStore.create({ client: { tove: failedToveStub }})
+      rootStore = AppStore.create({ client: { tove: mockJWT(failedToveStub), toveZip: mockJWT() }})
       workflowsStore = rootStore.workflows
     })
 


### PR DESCRIPTION
As we know from ASM, Panoptes tokens will expire after two hours. The difference between this app and ASM is that we're using auth here, where we used oauth in ASM. Oauth needed a redirect to allow a bearer token refresh. Auth does not require a redirect, so we can refresh the token staying in the same spot.

However, all calls need to be wrapped in a bearer token check to make sure we always have a valid token and are sending that back to TOVE. This PR should handle all of that. However, depending on when this merges, I'll have to update other open PRs to use this sort of wrapper around outgoing TOVE calls.

Closes #82 