### PR TITLE
Allow Transcriptions Index Page to Load Without Text Object

### DIFF
--- a/src/screens/SubjectsIndex/table.js
+++ b/src/screens/SubjectsIndex/table.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text } from 'grommet'
+import { Box, Text } from 'grommet'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircle } from '@fortawesome/free-solid-svg-icons'
 import styled from 'styled-components'
@@ -41,7 +41,7 @@ const columns = [
   {
     property: "flagged",
     header: "Flag",
-    render: datum => datum.flagged ? <StyledFontAwesomeIcon color='tomato' icon={faCircle} /> : null
+    render: datum => datum.flagged ? <Box><StyledFontAwesomeIcon color='tomato' icon={faCircle} /></Box> : null
   },
   {
     property: "consensusScore",

--- a/src/store/AppStore.spec.js
+++ b/src/store/AppStore.spec.js
@@ -15,9 +15,7 @@ const selectProjectSpy = jest.fn().mockResolvedValue(null)
 const selectWorkflowSpy = jest.fn().mockResolvedValue(null)
 const selectGroupSpy = jest.fn()
 const selectTranscriptionSpy = jest.fn().mockResolvedValue(null)
-const resetProjectsSpy = jest.fn()
-const resetWorkflowsSpy = jest.fn()
-const resetGroupsSpy = jest.fn()
+const selectGroupsSpy = jest.fn()
 const resetTransciptionsSpy = jest.fn()
 
 describe('AppStore', function () {
@@ -83,25 +81,17 @@ describe('AppStore', function () {
 
     it('should reset resources without params', async function () {
       Object.defineProperty(
-        appStore.projects, 'selectProject',
-        { writable: true, value: resetProjectsSpy }
-      )
-      Object.defineProperty(
-        appStore.workflows, 'selectWorkflow',
-        { writable: true, value: resetWorkflowsSpy }
-      )
-      Object.defineProperty(
         appStore.groups, 'selectGroup',
-        { writable: true, value: resetGroupsSpy }
+        { writable: true, value: selectGroupsSpy }
       )
       Object.defineProperty(
-        appStore.transcriptions, 'selectTranscription',
+        appStore.transcriptions, 'reset',
         { writable: true, value: resetTransciptionsSpy }
       )
       await appStore.getResources({})
-      expect(resetProjectsSpy).toHaveBeenCalled()
-      expect(resetWorkflowsSpy).toHaveBeenCalled()
-      expect(resetGroupsSpy).toHaveBeenCalled()
+      expect(selectProjectSpy).toHaveBeenCalled()
+      expect(selectWorkflowSpy).toHaveBeenCalled()
+      expect(selectGroupsSpy).toHaveBeenCalled()
       expect(resetTransciptionsSpy).toHaveBeenCalled()
     })
   })

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -42,7 +42,8 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   },
 
   createTranscription: (transcription) => {
-    const text = transcription.attributes.text
+    const text = (transcription.attributes && transcription.attributes.text) || {}
+    console.log(text);
     const pages = Object.keys(text).filter(key => key.includes('frame')).length
     const containsFrameKey = (val, key) => key.indexOf('frame') >= 0
     const textObject = Ramda.pickBy(containsFrameKey, transcription.attributes.text)

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -43,7 +43,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   createTranscription: (transcription) => {
     const text = (transcription.attributes && transcription.attributes.text) || {}
-    console.log(text);
     const pages = Object.keys(text).filter(key => key.includes('frame')).length
     const containsFrameKey = (val, key) => key.indexOf('frame') >= 0
     const textObject = Ramda.pickBy(containsFrameKey, transcription.attributes.text)
@@ -133,7 +132,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   reset: () => {
     getRoot(self).aggregations.setModal(false)
-    self.selectTranscription(null)
+    self.current = undefined
     self.all.clear()
   },
 
@@ -158,11 +157,10 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }),
 
   selectTranscription: flow(function * selectTranscription(id = null) {
-    let transcription = self.all.get(id)
-    if (!transcription) transcription = yield self.fetchTranscription(id)
-    if (id) yield self.fetchExtracts(id)
+    const transcription = yield self.fetchTranscription(id)
+    yield self.fetchExtracts(id)
     self.setTranscription(transcription)
-    self.current = id || undefined
+    self.current = id
   }),
 
   setTextObject: (text) => {


### PR DESCRIPTION
Due to a recent change in [how we serialize the text object](https://github.com/zooniverse/tove/pull/135), the index page was no longer loading without text objects. This PR should fix that issue.

A later backend change is coming which will allow items once held in the text object (consensus score, transcribed lines, and pages) to be pulled from the transcription object.