### PR TITLE
Refactor and Save Original Transcriber

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "stage": "export REACT_APP_ENV=development; export PATH_ROOT=preview.zooniverse.org/alice; yarn build && yarn _publish",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --coverage --watchAll=false --silent",
+    "test": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "stage": "export REACT_APP_ENV=development; export PATH_ROOT=preview.zooniverse.org/alice; yarn build && yarn _publish",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --coverage --watchAll=false",
+    "test": "react-scripts test --coverage --watchAll=false --silent",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/src/components/LineViewer/LineViewer.js
+++ b/src/components/LineViewer/LineViewer.js
@@ -40,16 +40,19 @@ function LineViewer ({
   toggleDeleteModal
 }) {
   const replaceWithSelected = () => {
+    let originalTranscriber = ''
     let textOption = ''
+
     if (selectedItem === algorithmChoice) {
       textOption = reduction.consensus_text
     } else if (selectedItem === typedChoice) {
       textOption = inputText
     } else {
+      originalTranscriber = transcriptionOptions[selectedItem].user
       textOption = transcriptionOptions[selectedItem].text
     }
     const isAlgorithmChoice = selectedItem === algorithmChoice
-    reduction.setConsensusText(textOption, isAlgorithmChoice)
+    reduction.setConsensusText(textOption, isAlgorithmChoice, originalTranscriber)
   }
 
   return (

--- a/src/components/LineViewer/LineViewer.spec.js
+++ b/src/components/LineViewer/LineViewer.spec.js
@@ -11,7 +11,7 @@ const transcriptionOptions = [
   {
     date: '',
     goldStandard: false,
-    userName: 'Anonymous',
+    user: 'A_User',
     text: 'Testing'
   }
 ]
@@ -89,19 +89,19 @@ describe('Component > LineViewer', function () {
     it('should replace with a transcription', function () {
       wrapper.setProps({ selectedItem: 0 })
       wrapper.find(Button).at(2).props().onClick()
-      expect(setConsensusTextSpy).toHaveBeenCalledWith('Testing', false)
+      expect(setConsensusTextSpy).toHaveBeenCalledWith('Testing', false, 'A_User')
     })
 
     it('should replace with a typed transcription', function () {
       wrapper.setProps({ selectedItem: 2 })
       wrapper.find(Button).at(2).props().onClick()
-      expect(setConsensusTextSpy).toHaveBeenCalledWith('Input Field', false)
+      expect(setConsensusTextSpy).toHaveBeenCalledWith('Input Field', false, '')
     })
 
     it('should replace with the algorithm', function () {
       wrapper.setProps({ selectedItem: 1 })
       wrapper.find(Button).at(2).props().onClick()
-      expect(setConsensusTextSpy).toHaveBeenCalledWith(reduction.consensus_text, true)
+      expect(setConsensusTextSpy).toHaveBeenCalledWith(reduction.consensus_text, true, '')
     })
   })
 

--- a/src/components/LineViewer/LineViewerContainer.js
+++ b/src/components/LineViewer/LineViewerContainer.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import AppContext from 'store'
 import { observer, useLocalStore } from 'mobx-react'
-import { constructText } from 'helpers/parseTranscriptionData'
 import LineViewer from './LineViewer'
 
 function LineViewerContainer() {
@@ -41,16 +40,8 @@ function LineViewerContainer() {
   }
 
   React.useEffect(() => {
-    const transcriptionArray = constructText(reduction).map((text, i) => {
-      return {
-        date: '',
-        goldStandard: (reduction.gold_standard && reduction.gold_standard[i]) || false,
-        userName: 'Anonymous',
-        text
-      }
-    })
-    localStore.setTranscriptionOptions(transcriptionArray)
-  }, [localStore, reduction])
+    localStore.setTranscriptionOptions(store.transcriptions.parsedExtracts[transcriptionIndex])
+  }, [localStore, store.transcriptions.parsedExtracts, transcriptionIndex])
 
   return (
     <LineViewer

--- a/src/components/LineViewer/LineViewerContainer.js
+++ b/src/components/LineViewer/LineViewerContainer.js
@@ -40,7 +40,9 @@ function LineViewerContainer() {
   }
 
   React.useEffect(() => {
-    localStore.setTranscriptionOptions(store.transcriptions.parsedExtracts[transcriptionIndex])
+    if (store.transcriptions.parsedExtracts && transcriptionIndex !== undefined) {
+      localStore.setTranscriptionOptions(store.transcriptions.parsedExtracts[transcriptionIndex])
+    }
   }, [localStore, store.transcriptions.parsedExtracts, transcriptionIndex])
 
   return (

--- a/src/components/LineViewer/LineViewerContainer.spec.js
+++ b/src/components/LineViewer/LineViewerContainer.spec.js
@@ -31,6 +31,7 @@ const contextValues = {
     activeTranscriptionIndex: 0,
     current: currentTranscription,
     index: 0,
+    parsedExtracts: [{}],
     setActiveTranscription: setActiveTranscriptionSpy
   }
 }

--- a/src/components/LineViewer/LineViewerContainer.spec.js
+++ b/src/components/LineViewer/LineViewerContainer.spec.js
@@ -31,7 +31,7 @@ const contextValues = {
     activeTranscriptionIndex: 0,
     current: currentTranscription,
     index: 0,
-    parsedExtracts: [{}],
+    parsedExtracts: [[{}]],
     setActiveTranscription: setActiveTranscriptionSpy
   }
 }

--- a/src/components/LineViewer/components/TranscriptionLine.js
+++ b/src/components/LineViewer/components/TranscriptionLine.js
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { observer } from 'mobx-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faStar } from '@fortawesome/free-solid-svg-icons'
+import writeDate from 'helpers/writeDate'
 import indexToColor from '../../../helpers/indexToColor'
 
 const ItalicText = styled(Text)`
@@ -16,6 +17,7 @@ const StyledBox = styled(Box)`
 `
 
 function TranscriptionLine ({ isViewer, selectedItem, setItem, transcription, index }) {
+  const timeString = transcription.time && transcription.time.toLocaleTimeString([], { hour: '2-digit', hour12: false, minute: '2-digit' });
   return (
     <Box height={{ min: '2em' }}>
       <Box direction='row' justify='between'>
@@ -50,9 +52,11 @@ function TranscriptionLine ({ isViewer, selectedItem, setItem, transcription, in
           </Box>
         )}
       </Box>
-      <Box direction='row' margin={{ left: '4em' }}>
-        <ItalicText>{transcription.date}</ItalicText>
-        <Text margin={{ horizontal: 'xsmall' }}>&#8226;</Text>
+      <Box direction='row' gap='xsmall' margin={{ left: '3em' }}>
+        <ItalicText>{writeDate(transcription.time)}</ItalicText>
+        <Text>&#8226;</Text>
+        <ItalicText>{timeString}</ItalicText>
+        <Text>&#8226;</Text>
         <ItalicText size='xsmall'>{transcription.userName}</ItalicText>
         {transcription.goldStandard && (
           <Box direction='row'>
@@ -70,10 +74,10 @@ TranscriptionLine.defaultProps = {
   selectedItem: null,
   setItem: () => {},
   transcription: {
-    date: '',
     goldStandard: false,
+    time: null,
     text: '',
-    userName: ''
+    userName: null
   },
   index: 0
 }
@@ -83,10 +87,10 @@ TranscriptionLine.propTypes = {
   selectedItem: PropTypes.number,
   setItem: PropTypes.func,
   transcription: PropTypes.shape({
-    date: PropTypes.string,
     goldStandard: PropTypes.bool,
+    time: PropTypes.shape(),
     text: PropTypes.string,
-    userName: PropTypes.string
+    userName: PropTypes.number
   }),
   index: PropTypes.number
 }

--- a/src/components/LineViewer/components/TranscriptionLine.js
+++ b/src/components/LineViewer/components/TranscriptionLine.js
@@ -6,6 +6,7 @@ import { observer } from 'mobx-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faStar } from '@fortawesome/free-solid-svg-icons'
 import writeDate from 'helpers/writeDate'
+import AppContext from 'store'
 import indexToColor from '../../../helpers/indexToColor'
 
 const ItalicText = styled(Text)`
@@ -17,6 +18,9 @@ const StyledBox = styled(Box)`
 `
 
 function TranscriptionLine ({ isViewer, selectedItem, setItem, transcription, index }) {
+  const store = React.useContext(AppContext)
+  const userName = store.transcriptions.extractUsers && store.transcriptions.extractUsers[transcription.userId]
+
   const timeString = transcription.time && transcription.time.toLocaleTimeString([], { hour: '2-digit', hour12: false, minute: '2-digit' });
   return (
     <Box height={{ min: '2em' }}>
@@ -52,15 +56,15 @@ function TranscriptionLine ({ isViewer, selectedItem, setItem, transcription, in
           </Box>
         )}
       </Box>
-      <Box direction='row' gap='xsmall' margin={{ left: '3em' }}>
+      <Box direction='row' gap='xxsmall' margin={{ left: '3em' }} wrap>
         <ItalicText>{writeDate(transcription.time)}</ItalicText>
         <Text>&#8226;</Text>
         <ItalicText>{timeString}</ItalicText>
         <Text>&#8226;</Text>
-        <ItalicText size='xsmall'>{transcription.userName}</ItalicText>
+        <ItalicText size='xsmall'>{userName}</ItalicText>
         {transcription.goldStandard && (
-          <Box direction='row'>
-            <Text margin={{ horizontal: 'xsmall' }}>&#8226;</Text>
+          <Box direction='row' gap='xxsmall'>
+            <Text>&#8226;</Text>
             <ItalicText>Gold Standard</ItalicText>
           </Box>
         )}

--- a/src/components/LineViewer/components/TranscriptionLine.js
+++ b/src/components/LineViewer/components/TranscriptionLine.js
@@ -6,7 +6,6 @@ import { observer } from 'mobx-react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faStar } from '@fortawesome/free-solid-svg-icons'
 import writeDate from 'helpers/writeDate'
-import AppContext from 'store'
 import indexToColor from '../../../helpers/indexToColor'
 
 const ItalicText = styled(Text)`
@@ -18,9 +17,6 @@ const StyledBox = styled(Box)`
 `
 
 function TranscriptionLine ({ isViewer, selectedItem, setItem, transcription, index }) {
-  const store = React.useContext(AppContext)
-  const userName = store.transcriptions.extractUsers && store.transcriptions.extractUsers[transcription.userId]
-
   const timeString = transcription.time && transcription.time.toLocaleTimeString([], { hour: '2-digit', hour12: false, minute: '2-digit' });
   return (
     <Box height={{ min: '2em' }}>
@@ -61,7 +57,7 @@ function TranscriptionLine ({ isViewer, selectedItem, setItem, transcription, in
         <Text>&#8226;</Text>
         <ItalicText>{timeString}</ItalicText>
         <Text>&#8226;</Text>
-        <ItalicText size='xsmall'>{userName}</ItalicText>
+        <ItalicText size='xsmall'>{transcription.user}</ItalicText>
         {transcription.goldStandard && (
           <Box direction='row' gap='xxsmall'>
             <Text>&#8226;</Text>

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
@@ -13,7 +13,7 @@ function AnnotationsPaneContainer({ x, y }) {
   const validExtracts = store.transcriptions.extracts.filter(extract => extract.data[`frame${index}`])
   const extractsByUser = validExtracts.reduce((list, extract) => {
     if (!list[extract.userId]) list[extract.userId] = []
-    list[extract.userId].push(extract.data)
+    list[extract.userId].push({ ...extract.data, time: extract.classificationAt })
     return list
   }, {})
 

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
@@ -2,40 +2,26 @@ import React from 'react'
 import { observer } from 'mobx-react'
 import AppContext from 'store'
 import AnnotationsPane from './AnnotationsPane'
-import { constructCoordinates, constructText, mapExtractsToReductions } from 'helpers/parseTranscriptionData'
+import { constructCoordinates } from 'helpers/parseTranscriptionData'
 
 function AnnotationsPaneContainer({ x, y }) {
-  let [ extractLines, reductionLines ] = [[], []]
+  let reductionLines = []
   const store = React.useContext(AppContext)
   const index = store.transcriptions.index
   const transcription = store.transcriptions.current
-
-  const validExtracts = store.transcriptions.extracts.filter(extract => extract.data[`frame${index}`])
-  const extractsByUser = validExtracts.reduce((list, extract) => {
-    if (!list[extract.userId]) list[extract.userId] = []
-    list[extract.userId].push({ ...extract.data, time: extract.classificationAt })
-    return list
-  }, {})
-
   const transcriptionFrame = transcription && transcription.text && transcription.text.get(`frame${index}`)
 
   if (transcriptionFrame) {
     reductionLines = transcriptionFrame.map(transcription => constructCoordinates(transcription))
-    const reductionText = transcriptionFrame.map(transcription => constructText(transcription))
-    transcriptionFrame.forEach((reduction, reductionIndex) => {
-      extractLines.push(mapExtractsToReductions(extractsByUser, reduction, reductionIndex, reductionText, index))
-    })
   }
-
-  const lines = { extractLines, reductionLines }
 
   return (
     <AnnotationsPane
       x={x}
       y={y}
       linesVisible={store.editor.linesVisible}
-      extractLines={lines.extractLines}
-      reductionLines={lines.reductionLines}
+      extractLines={store.transcriptions.parsedExtracts}
+      reductionLines={reductionLines}
     />
   )
 }

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
@@ -21,7 +21,7 @@ export default function SVGLines({ lines, isExtract, reductionIndex }) {
             cx={line.x1}
             cy={line.y1}
             r={circleWidth}
-            fill={color}
+            fill='transparent'
             stroke={color}
             strokeWidth={strokeWidth}
           />
@@ -32,7 +32,7 @@ export default function SVGLines({ lines, isExtract, reductionIndex }) {
             cx={line.x2}
             cy={line.y2}
             r={circleWidth}
-            fill='transparent'
+            fill={color}
             stroke={color}
             strokeWidth={strokeWidth}
           />

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -1,3 +1,5 @@
+const SLOPE_BUFFER = 10;
+
 function constructCoordinates(line) {
   const points = [];
 
@@ -35,25 +37,43 @@ function mapExtractsToReductions(
 ) {
   const result = []
 
-  reduction.user_ids && reduction.user_ids.forEach((id, userIdIndex) => {
-    extractsByUser[id] && extractsByUser[id].forEach(extract => {
-      if (extract[`frame${subjectIndex}`]) {
-        const extractLocation = extract[`frame${subjectIndex}`].text[reduction.extract_index[userIdIndex]]
-        if (extractLocation && extractLocation[0] === reductionText[reductionIndex][userIdIndex]) {
-          const annotationIndexToExtract = reduction.extract_index[userIdIndex]
-          const points = extract[`frame${subjectIndex}`].points
-          const lastIndex = points.x[annotationIndexToExtract].length - 1
+  reduction.user_ids.forEach((userId, idIndex) => {
+    // lets find that user's annotation
+    const userClassificationsOnSubject = extractsByUser[userId]
+    for (let i = 0; i < userClassificationsOnSubject.length; i++) {
+      const classification = userClassificationsOnSubject[i]
+      const currentFrame = `frame${subjectIndex}`
+      if (classification[currentFrame]) {
+        // Get the extract_index value at this user_id index
+        // this tells you which extract index to consider
+        const extractIndex = reduction.extract_index[idIndex]
+        // check this classification at that index
+        const text = classification[currentFrame].text[extractIndex]
+        const points = classification[currentFrame].points
+
+        // check slope is similar to reduction
+        const extractSlope = classification[currentFrame].slope[extractIndex]
+        const reductionSlope = reduction.line_slope
+        const similarSlope = Math.abs(Math.abs(extractSlope) - Math.abs(reductionSlope)) < SLOPE_BUFFER
+
+        const isMatch = text && text[0] === reductionText[reductionIndex][idIndex]
+        // see if that text exists and if it matches the reductionText
+        if (isMatch && similarSlope) {
+          const lastIndex = points.x[extractIndex].length - 1
           result.push({
-            x1: points.x[annotationIndexToExtract][0],
-            x2: points.x[annotationIndexToExtract][lastIndex],
-            y1: points.y[annotationIndexToExtract][0],
-            y2: points.y[annotationIndexToExtract][lastIndex]
+            userId,
+            text: text[0],
+            slope: classification[currentFrame].slope[extractIndex],
+            x1: points.x[extractIndex][0],
+            x2: points.x[extractIndex][lastIndex],
+            y1: points.y[extractIndex][0],
+            y2: points.y[extractIndex][lastIndex]
           })
+          break;
         }
       }
-    })
+    }
   })
-
   return result
 }
 

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -53,14 +53,17 @@ function mapExtractsToReductions(
 
         // check slope is similar to reduction
         const extractSlope = classification[currentFrame].slope[extractIndex]
+
         const reductionSlope = reduction.line_slope
         const similarSlope = Math.abs(Math.abs(extractSlope) - Math.abs(reductionSlope)) < SLOPE_BUFFER
-
         const isMatch = text && text[0] === reductionText[reductionIndex][idIndex]
         // see if that text exists and if it matches the reductionText
         if (isMatch && similarSlope) {
           const lastIndex = points.x[extractIndex].length - 1
+          const time = new Date(0)
+          time.setUTCSeconds(classification.time)
           result.push({
+            time,
             userId,
             text: text[0],
             slope: classification[currentFrame].slope[extractIndex],

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -63,10 +63,11 @@ function mapExtractsToReductions(
           const time = new Date(0)
           time.setUTCSeconds(classification.time)
           result.push({
+            goldStandard: reduction.gold_standard[idIndex],
+            slope: classification[currentFrame].slope[extractIndex],
+            text: text[0],
             time,
             userId,
-            text: text[0],
-            slope: classification[currentFrame].slope[extractIndex],
             x1: points.x[extractIndex][0],
             x2: points.x[extractIndex][lastIndex],
             y1: points.y[extractIndex][0],

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -37,7 +37,7 @@ function mapExtractsToReductions(
   extractUsers = {}
 ) {
   const result = []
-  reduction.user_ids.forEach((userId, idIndex) => {
+  reduction.user_ids && reduction.user_ids.forEach((userId, idIndex) => {
     // lets find that user's annotation
     const userClassificationsOnSubject = extractsByUser[userId]
     for (let i = 0; i < userClassificationsOnSubject.length; i++) {

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -34,9 +34,9 @@ function mapExtractsToReductions(
   reductionIndex = 0,
   reductionText = [],
   subjectIndex = 0,
+  extractUsers = {}
 ) {
   const result = []
-
   reduction.user_ids.forEach((userId, idIndex) => {
     // lets find that user's annotation
     const userClassificationsOnSubject = extractsByUser[userId]
@@ -67,7 +67,7 @@ function mapExtractsToReductions(
             slope: classification[currentFrame].slope[extractIndex],
             text: text[0],
             time,
-            userId,
+            user: extractUsers[userId],
             x1: points.x[extractIndex][0],
             x2: points.x[extractIndex][lastIndex],
             y1: points.y[extractIndex][0],

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -40,6 +40,7 @@ function mapExtractsToReductions(
   reduction.user_ids && reduction.user_ids.forEach((userId, idIndex) => {
     // lets find that user's annotation
     const userClassificationsOnSubject = extractsByUser[userId]
+    if (!userClassificationsOnSubject) return null
     for (let i = 0; i < userClassificationsOnSubject.length; i++) {
       const classification = userClassificationsOnSubject[i]
       const currentFrame = `frame${subjectIndex}`

--- a/src/helpers/parseTranscriptionData.spec.js
+++ b/src/helpers/parseTranscriptionData.spec.js
@@ -10,7 +10,7 @@ const line = {
   clusters_x: [0, 100],
   clusters_y: [100, 200]
 }
-const extract = {
+export const mockExtract = {
   frame0: {
     slope: [0],
     text: [['My text for this line']],
@@ -22,9 +22,9 @@ const extract = {
   time: date
 }
 const extractsByUser = {
-  1: [extract]
+  1: [mockExtract]
 }
-const reduction = {
+export const mockReduction = {
   gold_standard: [false],
   line_slope: 0,
   extract_index: [0],
@@ -66,7 +66,7 @@ describe('Helper > constructText', function () {
 
 describe('Helper > mapExtractsToReductions', function () {
   it('returns data needed for a line', function () {
-    const result = mapExtractsToReductions(extractsByUser, reduction, 0, reductionText, 0)
+    const result = mapExtractsToReductions(extractsByUser, mockReduction, 0, reductionText, 0)
     const time = new Date(0)
     time.setUTCSeconds(date)
     const expectation = {

--- a/src/helpers/parseTranscriptionData.spec.js
+++ b/src/helpers/parseTranscriptionData.spec.js
@@ -1,5 +1,7 @@
 import { constructCoordinates, constructText, mapExtractsToReductions } from './parseTranscriptionData'
 
+const date = new Date()
+
 const line = {
   clusters_text: [
     ['Hello', 'Hello', ''],
@@ -10,19 +12,23 @@ const line = {
 }
 const extract = {
   frame0: {
+    slope: [0],
     text: [['My text for this line']],
     points: {
       x: [[200, 200]],
       y: [[300, 300]]
     }
-  }
+  },
+  time: date
 }
 const extractsByUser = {
   1: [extract]
 }
 const reduction = {
-  user_ids: [1],
-  extract_index: [0]
+  gold_standard: [false],
+  line_slope: 0,
+  extract_index: [0],
+  user_ids: [1]
 }
 const reductionText = [['My text for this line']]
 
@@ -61,7 +67,17 @@ describe('Helper > constructText', function () {
 describe('Helper > mapExtractsToReductions', function () {
   it('returns data needed for a line', function () {
     const result = mapExtractsToReductions(extractsByUser, reduction, 0, reductionText, 0)
-    const expectation = { x1: 200, x2: 200, y1: 300, y2: 300 }
+    const time = new Date(0)
+    time.setUTCSeconds(date)
+    const expectation = {
+      goldStandard: false,
+      slope: 0,
+      text: 'My text for this line',
+      x1: 200,
+      x2: 200,
+      y1: 300,
+      y2: 300,
+      time }
     expect(result).toEqual([expectation])
   })
 

--- a/src/helpers/writeDate.js
+++ b/src/helpers/writeDate.js
@@ -14,8 +14,9 @@ const MONTHS = [
 ]
 
 export default function writeDate(date) {
-  if (!date || !date.length) return ''
-  const dateObject = new Date(date)
+  if (!date) return
+  if (typeof date === 'string' && !date.length) return ''
+  const dateObject = typeof date === 'string' ? new Date(date) : date
   const month = MONTHS[dateObject.getMonth()]
   const day = dateObject.getDate()
   const year = dateObject.getFullYear()

--- a/src/helpers/writeDate.js
+++ b/src/helpers/writeDate.js
@@ -14,7 +14,7 @@ const MONTHS = [
 ]
 
 export default function writeDate(date) {
-  if (!date) return
+  if (!date) return ''
   if (typeof date === 'string' && !date.length) return ''
   const dateObject = typeof date === 'string' ? new Date(date) : date
   const month = MONTHS[dateObject.getMonth()]

--- a/src/store/Reduction.js
+++ b/src/store/Reduction.js
@@ -15,15 +15,17 @@ const Reduction = types.model('Reduction', {
   line_slope: types.optional(types.number, 0),
   low_consensus: types.optional(types.boolean, false),
   number_views: types.optional(types.integer, 0),
+  original_transcriber: types.optional(types.string, ''),
   seen: types.optional(types.boolean, false),
   slope_label: types.optional(types.integer, 0),
   user_ids: types.array(types.maybeNull(types.integer))
 })
 .actions(self => ({
-  setConsensusText: (text, isOriginalOption = false) => {
+  setConsensusText: (text, isOriginalOption = false, originalTranscriber = '') => {
+    self.original_transcriber = originalTranscriber
     self.line_editor = isOriginalOption ? '' : getRoot(self).auth.user.display_name
     self.edited_consensus_text = isOriginalOption ? '' : text
-    
+
     const transcription = getRoot(self).transcriptions
     transcription.saveTranscription()
   },

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -109,24 +109,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     self.setParsedExtracts(arrangedExtractsByUser)
   })
 
-  const fetchTranscription = flow(function * fetchTranscription(id) {
-    if (!id) return undefined
-    undoManager.withoutUndo(() => self.asyncState = ASYNC_STATES.LOADING)
-    const client = getRoot(self).client.tove
-    try {
-      const response = yield client.get(`/transcriptions/${id}`)
-      const resource = JSON.parse(response.body)
-      undoManager.withoutUndo(() => self.asyncState = ASYNC_STATES.READY)
-      return self.createTranscription(resource.data)
-    } catch (error) {
-      console.warn(error);
-      undoManager.withoutUndo(() => {
-        self.error = error.message
-        self.asyncState = ASYNC_STATES.ERROR
-      })
-    }
-  })
-
   const fetchTranscriptions = function * fetchTranscriptions(page = 0) {
     self.reset()
     self.page = page
@@ -285,7 +267,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     createTranscription: (transcription) => undoManager.withoutUndo(() => createTranscription(transcription)),
     deleteCurrentLine,
     fetchExtracts,
-    fetchTranscription,
     fetchTranscriptions: (page) => undoManager.withoutUndo(() => flow(fetchTranscriptions))(page),
     getTranscriberInfo,
     reset: () => undoManager.withoutUndo(() => reset()),

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -83,7 +83,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const query = `{
       workflow(id: ${workflowId}) {
         extracts(subjectId: ${id}, extractorKey: "ext-17") {
-          data, userId
+          data, userId, classificationAt
         }
       }
     }`

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -245,7 +245,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
       try {
         self.all.put(transcription)
       } catch (error) {
-        console.error(error)
+        console.warn(error)
       }
     }
   }

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -94,7 +94,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     // with the correct 'alice' key.
     const query = `{
       workflow(id: ${workflowId}) {
-        extracts(subjectId: ${id}, extractorKey: "ext-17") {
+        extracts(subjectId: ${id}, extractorKey: "alice") {
           data, userId, classificationAt
         }
       }

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -105,7 +105,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     })
     self.rawExtracts = validExtracts
     const arrangedExtractsByUser = self.arrangeExtractsByUser()
-    self.getTranscriberInfo(arrangedExtractsByUser)
+    yield self.getTranscriberInfo(arrangedExtractsByUser)
     self.setParsedExtracts(arrangedExtractsByUser)
   }
 
@@ -216,7 +216,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const transcriptionFrame = self.current && self.current.text && self.current.text.get(`frame${index}`)
     const reductionText = transcriptionFrame && transcriptionFrame.map(transcription => constructText(transcription))
     transcriptionFrame && transcriptionFrame.forEach((reduction, reductionIndex) => {
-      extracts.push(mapExtractsToReductions(extractsByUser, reduction, reductionIndex, reductionText, index))
+      extracts.push(mapExtractsToReductions(extractsByUser, reduction, reductionIndex, reductionText, index, self.extractUsers))
     })
     self.parsedExtracts = extracts
   }

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -1,5 +1,6 @@
 import ASYNC_STATES from 'helpers/asyncStates'
 import * as graphQl from 'graphql-request'
+import apiClient from 'panoptes-client/lib/api-client.js';
 import { AppStore } from './AppStore'
 import TranscriptionFactory from './factories/transcription'
 
@@ -11,10 +12,18 @@ const extracts = {
     extracts: [{
       data: {
         frame0: {}
-      }
+      },
+      userId: '123',
+      classificationAt: 1515450629.237
     }]
   }
 }
+
+const user = {
+  id: '123',
+  display_name: 'A_User'
+}
+
 let simpleTranscription = TranscriptionFactory.build({ status: 'approved' })
 let mockReduction = {
   clusters_text: [],
@@ -31,6 +40,7 @@ let mockReduction = {
   line_slope: 0,
   low_consensus: false,
   number_views: 0,
+  original_transcriber: '',
   seen: false,
   slope_label: 0,
   user_ids: []
@@ -71,13 +81,8 @@ let failedToveStub = {
 }
 
 describe('TranscriptionsStore', function () {
-  describe('success state fetching multiple transcriptions', function () {
+  describe('fetching multiple transcriptions', function () {
     beforeEach(async function () {
-      jest
-        .spyOn(graphQl, 'request')
-        .mockImplementation(() => {
-          return Promise.resolve(extracts)
-        })
       rootStore = AppStore.create({
         client: { tove: successfulToveStub },
         groups: {
@@ -113,88 +118,20 @@ describe('TranscriptionsStore', function () {
     it('should count the number of approved', async function () {
       expect(transcriptionsStore.approvedCount).toBe(1)
     })
-
-    it('should fetch transcriptions for a subject', async function () {
-      await transcriptionsStore.selectTranscription(1)
-      const transcription = transcriptionsStore.createTranscription(simpleTranscription)
-      expect(transcriptionsStore.current).toEqual(transcription)
-    })
-
-    it('should return the current transcription state', async function () {
-      await transcriptionsStore.selectTranscription(1)
-      expect(transcriptionsStore.approved).toBe(false)
-      expect(transcriptionsStore.title).toBe("1")
-    })
-
-    it('should set the active transcription', function () {
-      transcriptionsStore.setActiveTranscription(5)
-      expect(transcriptionsStore.activeTranscriptionIndex).toBe(5)
-    })
-
-    it('should delete a transcription line', async function () {
-      await transcriptionsStore.selectTranscription(1)
-      const current = transcriptionsStore.current.text.get('frame0')
-      expect(current.length).toBe(1)
-      transcriptionsStore.setActiveTranscription(0)
-      transcriptionsStore.deleteCurrentLine()
-      expect(current.length).toBe(0)
-      expect(patchToveSpy).toHaveBeenCalled()
-    })
-
-    it('should not delete an inactive transcription line', async function () {
-      await transcriptionsStore.selectTranscription(1)
-      transcriptionsStore.deleteCurrentLine()
-      expect(patchToveSpy).not.toHaveBeenCalled()
-    })
-
-    describe('after selecting a transcription', function () {
-      beforeEach(async function () {
-        await transcriptionsStore.selectTranscription(1)
-      })
-
-      it('should select the correct transcription', async function () {
-        const transcription = transcriptionsStore.createTranscription(simpleTranscription)
-        expect(transcriptionsStore.current).toEqual(transcription)
-      })
-
-      it('should edit the text object', async function () {
-        const textObject = [mockReduction]
-        transcriptionsStore.setTextObject([mockReduction])
-        expect(transcriptionsStore.current.text.get('frame0')).toEqual(textObject)
-      })
-
-      it('should save a transcription', async function () {
-        await transcriptionsStore.saveTranscription()
-        expect(patchToveSpy).toHaveBeenCalled()
-      })
-
-      it('should update the flagged attribute', function () {
-        expect(transcriptionsStore.current.flagged).toBe(false)
-        transcriptionsStore.setTextObject([mockReduction])
-        transcriptionsStore.checkForFlagUpdate()
-        expect(patchToveSpy).toHaveBeenCalled()
-        expect(transcriptionsStore.current.flagged).toBe(true)
-      })
-
-      describe('and attempting to undo', function () {
-        it('should not make a change', function () {
-          transcriptionsStore.undo()
-          expect(patchToveSpy).not.toHaveBeenCalled()
-        })
-      })
-
-      describe('and making a change', function () {
-        it('should undo the previous action', function () {
-          transcriptionsStore.setTextObject([mockReduction])
-          transcriptionsStore.undo()
-          expect(patchToveSpy).toHaveBeenCalled()
-        })
-      })
-    })
   })
 
-  describe('success state fetching single transcription', function () {
-    it('should fetch a single transcription', async function () {
+  describe('fetching a single transcription', function () {
+    beforeEach(async function () {
+      jest
+        .spyOn(graphQl, 'request')
+        .mockImplementation(() => Promise.resolve(extracts))
+      jest
+        .spyOn(apiClient, 'type')
+        .mockImplementation(() => {
+          return {
+            get: () => Promise.resolve([user])
+          }
+        })
       rootStore = AppStore.create({
         client: { tove: singleTranscriptionStub },
         groups: {
@@ -202,62 +139,165 @@ describe('TranscriptionsStore', function () {
             display_name: 'GROUP_1'
           }
         },
-        subject: {
-          index: 0
-        },
         workflows: {
           all: { 1: { id: '1' } },
           current: '1'
         }
       })
       transcriptionsStore = rootStore.transcriptions
-      const returnValue = await transcriptionsStore.fetchTranscription('1')
-      expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.READY)
-      expect(returnValue).toBeDefined()
+      await transcriptionsStore.selectTranscription(1)
     })
 
-    it('should be able to update an approval state', async function () {
-      await transcriptionsStore.selectTranscription(1)
+    it('should select a single transcription', function () {
+      const transcription = transcriptionsStore.createTranscription(simpleTranscription)
+      expect(transcriptionsStore.current).toEqual(transcription)
+    })
+
+    it('should set an active transcription', function () {
+      transcriptionsStore.setActiveTranscription(1)
+      expect(transcriptionsStore.activeTranscriptionIndex).toBe(1)
+    })
+
+    it('should update the approval status', async function () {
       await transcriptionsStore.updateApproval(false)
       expect(transcriptionsStore.readyForReview).toBe(true)
     })
-  })
 
-  describe('failure state', function () {
-    beforeEach(function() {
-      rootStore = AppStore.create({
-        client: { tove: failedToveStub },
-        groups: {
-          current: {
-            display_name: 'GROUP_1'
-          }
-        },
-        workflows: {
-          all: { 1: { id: '1' } },
-          current: '1'
-        }
-      })
-    })
-
-    it('should not set a workflow if give the wrong info', function () {
-      transcriptionsStore = rootStore.transcriptions
-      expect(transcriptionsStore.all.size).toBe(0)
-      transcriptionsStore.setTranscription(1)
-      expect(transcriptionsStore.all.size).toBe(0)
-    })
-
-    it('should handle an error when fetching transcriptions', async function () {
-      transcriptionsStore = rootStore.transcriptions
-      await transcriptionsStore.fetchTranscriptions()
-      expect(transcriptionsStore.error).toBe(error.message)
-      expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
-    })
-
-    it('should handle an error when fetching a transcription', async function () {
-      transcriptionsStore = rootStore.transcriptions
-      await transcriptionsStore.fetchTranscription('1')
-      expect(transcriptionsStore.error).toBe(error.message)
-      expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
+    it('should edit the text object', function () {
+      const textObject = [mockReduction]
+      transcriptionsStore.setTextObject([mockReduction])
+      expect(transcriptionsStore.current.text.get('frame0')).toEqual(textObject)
     })
   })
+
+    // it('should fetch transcriptions for a subject', async function () {
+    //   await transcriptionsStore.selectTranscription(1)
+    //   const transcription = transcriptionsStore.createTranscription(simpleTranscription)
+    //   expect(transcriptionsStore.current).toEqual(transcription)
+    // })
+
+    // it('should return the current transcription state', async function () {
+    //   await transcriptionsStore.selectTranscription(1)
+    //   expect(transcriptionsStore.approved).toBe(false)
+    //   expect(transcriptionsStore.title).toBe("1")
+    // })
+    //
+    // it('should set the active transcription', function () {
+    //   transcriptionsStore.setActiveTranscription(5)
+    //   expect(transcriptionsStore.activeTranscriptionIndex).toBe(5)
+    // })
+    //
+    // it('should delete a transcription line', async function () {
+    //   await transcriptionsStore.selectTranscription(1)
+    //   transcriptionsStore.setTextObject([mockReduction])
+    //   const current = transcriptionsStore.current.text.get('frame0')
+    //   expect(current.length).toBe(1)
+    //   transcriptionsStore.setActiveTranscription(0)
+    //   transcriptionsStore.deleteCurrentLine()
+    //   expect(current.length).toBe(0)
+    //   expect(patchToveSpy).toHaveBeenCalled()
+    // })
+    //
+    // it('should not delete an inactive transcription line', async function () {
+    //   await transcriptionsStore.selectTranscription(1)
+    //   transcriptionsStore.setTextObject([mockReduction])
+    //   const current = transcriptionsStore.current.text.get('frame0')
+    //   expect(current.length).toBe(1)
+    //   transcriptionsStore.deleteCurrentLine()
+    //   expect(patchToveSpy).not.toHaveBeenCalled()
+    // })
+
+  //   describe('after selecting a transcription', function () {
+  //     beforeEach(async function () {
+  //       await transcriptionsStore.selectTranscription(1)
+  //     })
+  //
+  //     it('should select the correct transcription', async function () {
+  //       const transcription = transcriptionsStore.createTranscription(simpleTranscription)
+  //       expect(transcriptionsStore.current).toEqual(transcription)
+  //     })
+  //
+  //     it('should edit the text object', async function () {
+  //       const textObject = [mockReduction]
+  //       transcriptionsStore.setTextObject([mockReduction])
+  //       expect(transcriptionsStore.current.text.get('frame0')).toEqual(textObject)
+  //     })
+  //
+  //     it('should save a transcription', async function () {
+  //       await transcriptionsStore.saveTranscription()
+  //       expect(patchToveSpy).toHaveBeenCalled()
+  //     })
+  //
+  //     it('should update the flagged attribute', function () {
+  //       expect(transcriptionsStore.current.flagged).toBe(false)
+  //       transcriptionsStore.setTextObject([mockReduction])
+  //       transcriptionsStore.checkForFlagUpdate()
+  //       expect(patchToveSpy).toHaveBeenCalled()
+  //       expect(transcriptionsStore.current.flagged).toBe(true)
+  //     })
+  //   })
+  // })
+
+  // describe('success state fetching single transcription', function () {
+  //   it('should fetch a single transcription', async function () {
+  //     rootStore = AppStore.create({
+  //       client: { tove: singleTranscriptionStub },
+  //       groups: {
+  //         current: {
+  //           display_name: 'GROUP_1'
+  //         }
+  //       },
+  //       subject: {
+  //         index: 0
+  //       },
+  //       workflows: {
+  //         all: { 1: { id: '1' } },
+  //         current: '1'
+  //       }
+  //     })
+  //     transcriptionsStore = rootStore.transcriptions
+  //     const returnValue = await transcriptionsStore.fetchTranscription('1')
+  //     expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.READY)
+  //     expect(returnValue).toBeDefined()
+  //   })
+  //
+  //   it('should be able to update an approval state', async function () {
+  //     await transcriptionsStore.selectTranscription(1)
+  //     await transcriptionsStore.updateApproval(false)
+  //     expect(transcriptionsStore.readyForReview).toBe(true)
+  //   })
+  // })
+
+  // describe('failure state', function () {
+  //   beforeEach(function() {
+  //     rootStore = AppStore.create({
+  //       client: { tove: failedToveStub },
+  //       groups: {
+  //         current: {
+  //           display_name: 'GROUP_1'
+  //         }
+  //       }
+  //     })
+  //   })
+  //
+  //   it('should not set a workflow if give the wrong info', function () {
+  //     transcriptionsStore = rootStore.transcriptions
+  //     expect(transcriptionsStore.all.size).toBe(0)
+  //     transcriptionsStore.setTranscription(1)
+  //     expect(transcriptionsStore.all.size).toBe(0)
+  //   })
+  //
+  //   it('should handle an error when fetching transcriptions', async function () {
+  //     transcriptionsStore = rootStore.transcriptions
+  //     await transcriptionsStore.fetchTranscriptions()
+  //     expect(transcriptionsStore.error).toBe(error.message)
+  //     expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
+  //   })
+  //
+  //   it('should handle an error when fetching a transcription', async function () {
+  //     transcriptionsStore = rootStore.transcriptions
+  //     await transcriptionsStore.fetchTranscription('1')
+  //     expect(transcriptionsStore.error).toBe(error.message)
+  //     expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
+  //   })
 })

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -192,6 +192,12 @@ describe('TranscriptionsStore', function () {
         expect(transcriptionsStore.all.size).toBe(1)
       })
 
+      it('should not attempt to set an empty transcription', function () {
+        expect(transcriptionsStore.current.id).toBe("1")
+        transcriptionsStore.setTranscription()
+        expect(transcriptionsStore.current.id).toBe("1")
+      })
+
       it('should save a transcription', function () {
         transcriptionsStore.saveTranscription()
         expect(patchToveSpy).toHaveBeenCalled()
@@ -215,6 +221,11 @@ describe('TranscriptionsStore', function () {
         expect(transcriptionsStore.readyForReview).toBe(false)
       })
 
+      it('should change the index', function () {
+        transcriptionsStore.changeIndex(1)
+        expect(transcriptionsStore.index).toBe(1)
+      })
+
       describe('when deleting a line', function () {
         it('should not proceed without an active transcription', function () {
           const current = transcriptionsStore.current.text.get('frame0')
@@ -230,6 +241,21 @@ describe('TranscriptionsStore', function () {
           expect(current.length).toBe(1)
           transcriptionsStore.deleteCurrentLine()
           expect(current.length).toBe(0)
+          expect(patchToveSpy).toHaveBeenCalled()
+        })
+      })
+
+      describe('and attempting to undo', function () {
+        it('should not make a change', function () {
+          transcriptionsStore.undo()
+          expect(patchToveSpy).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('and making a change', function () {
+        it('should undo the previous action', function () {
+          transcriptionsStore.setTextObject([mockReduction])
+          transcriptionsStore.undo()
           expect(patchToveSpy).toHaveBeenCalled()
         })
       })

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -1,31 +1,24 @@
 import ASYNC_STATES from 'helpers/asyncStates'
 import * as graphQl from 'graphql-request'
 import apiClient from 'panoptes-client/lib/api-client.js';
+import { mockExtract } from 'helpers/parseTranscriptionData.spec'
 import { AppStore } from './AppStore'
 import TranscriptionFactory from './factories/transcription'
 
-let transcriptionsStore
 let rootStore
-let patchToveSpy = jest.fn().mockResolvedValue(true)
+let transcriptionsStore
+
 const extracts = {
   workflow: {
     extracts: [{
-      data: {
-        frame0: {}
-      },
+      data: mockExtract,
       userId: '123',
       classificationAt: 1515450629.237
     }]
   }
 }
 
-const user = {
-  id: '123',
-  display_name: 'A_User'
-}
-
-let simpleTranscription = TranscriptionFactory.build({ status: 'approved' })
-let mockReduction = {
+const mockReduction = {
   clusters_text: [],
   clusters_x: [],
   clusters_y: [],
@@ -46,7 +39,15 @@ let mockReduction = {
   user_ids: []
 }
 
-let successfulToveStub = {
+const user = {
+  id: '123',
+  display_name: 'A_User'
+}
+
+const consoleSpy = jest.spyOn(console, 'warn')
+const patchToveSpy = jest.fn().mockResolvedValue(true)
+
+const multipleTranscriptionsStub = {
   get: () => Promise.resolve(
     {
       body: JSON.stringify(
@@ -61,243 +62,187 @@ let successfulToveStub = {
   patch: patchToveSpy
 }
 
-let singleTranscriptionStub = {
+const singleTranscriptionStub = {
   get: () => Promise.resolve(
     {
       body: JSON.stringify(
         {
-          data: TranscriptionFactory.build(),
+          data: TranscriptionFactory.build({
+            attributes: {
+              text: { frame0: [{}] }
+            }
+          }),
           meta: {
             pagination: { last: 1 }
           }
         })
     }
   ),
-  patch: () => Promise.resolve()
+  patch: patchToveSpy
 }
-const error = { message: 'Failed to Return' }
-let failedToveStub = {
-  get: () => Promise.reject(error)
+
+const failedToveStub = {
+  get: () => Promise.reject({ message: 'Failed to Return' })
 }
 
 describe('TranscriptionsStore', function () {
   describe('fetching multiple transcriptions', function () {
-    beforeEach(async function () {
-      rootStore = AppStore.create({
-        client: { tove: successfulToveStub },
-        groups: {
-          current: {
-            display_name: 'GROUP_1'
+    describe('success state', function () {
+      beforeEach(async function () {
+        rootStore = AppStore.create({
+          client: { tove: multipleTranscriptionsStub },
+          groups: {
+            current: {
+              display_name: 'GROUP_1'
+            }
+          },
+          workflows: {
+            all: { 1: { id: '1' } },
+            current: '1'
           }
-        },
-        workflows: {
-          all: { 1: { id: '1' } },
-          current: '1'
-        }
+        })
+        transcriptionsStore = rootStore.transcriptions
+        await transcriptionsStore.fetchTranscriptions()
       })
-      transcriptionsStore = rootStore.transcriptions
-      await transcriptionsStore.fetchTranscriptions()
+
+      afterEach(() => jest.clearAllMocks());
+
+      it('should exist', function () {
+        expect(transcriptionsStore).toBeDefined()
+      })
+
+      it('should fetch transcriptions', async function () {
+        expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.READY)
+        expect(transcriptionsStore.all.size).toBe(2)
+      })
+
+      it('should count the number of approved', async function () {
+        expect(transcriptionsStore.approvedCount).toBe(1)
+      })
+
+      it('should not select a transcription without an id', function () {
+        transcriptionsStore.selectTranscription()
+        expect(transcriptionsStore.current).toBe(undefined)
+      })
     })
 
-    afterEach(() => jest.clearAllMocks());
-
-    it('should exist', function () {
-      expect(transcriptionsStore).toBeDefined()
-    })
-
-    it('should change the index', function () {
-      transcriptionsStore.changeIndex(1)
-      expect(transcriptionsStore.index).toBe(1)
-    })
-
-    it('should fetch transcriptions', async function () {
-      expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.READY)
-      expect(transcriptionsStore.all.size).toBe(2)
-    })
-
-    it('should count the number of approved', async function () {
-      expect(transcriptionsStore.approvedCount).toBe(1)
+    describe('failure state', function () {
+      it('should register an error', async function () {
+        rootStore = AppStore.create({ client: { tove: failedToveStub }})
+        transcriptionsStore = rootStore.transcriptions
+        await transcriptionsStore.retrieveTranscriptions()
+        expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
+        expect(consoleSpy).toHaveBeenCalled()
+      })
     })
   })
 
   describe('fetching a single transcription', function () {
-    beforeEach(async function () {
-      jest
-        .spyOn(graphQl, 'request')
-        .mockImplementation(() => Promise.resolve(extracts))
-      jest
-        .spyOn(apiClient, 'type')
-        .mockImplementation(() => {
-          return {
-            get: () => Promise.resolve([user])
+    describe('success state', function () {
+      beforeEach(async function () {
+        jest
+          .spyOn(graphQl, 'request')
+          .mockImplementation(() => Promise.resolve(extracts))
+        jest
+          .spyOn(apiClient, 'type')
+          .mockImplementation(() => {
+            return {
+              get: () => Promise.resolve([user])
+            }
+          })
+        rootStore = AppStore.create({
+          client: { tove: singleTranscriptionStub },
+          groups: {
+            current: {
+              display_name: 'GROUP_1'
+            }
+          },
+          subjects: { index: 0 },
+          workflows: {
+            all: { 1: { id: '1' } },
+            current: '1'
           }
         })
-      rootStore = AppStore.create({
-        client: { tove: singleTranscriptionStub },
-        groups: {
-          current: {
-            display_name: 'GROUP_1'
-          }
-        },
-        workflows: {
-          all: { 1: { id: '1' } },
-          current: '1'
-        }
+        transcriptionsStore = rootStore.transcriptions
+        await transcriptionsStore.selectTranscription(1)
       })
-      transcriptionsStore = rootStore.transcriptions
-      await transcriptionsStore.selectTranscription(1)
+
+      afterEach(() => jest.clearAllMocks());
+
+      it('should return current transcription views', function () {
+        expect(transcriptionsStore.approved).toBe(false)
+        expect(transcriptionsStore.title).toBe('1')
+      })
+
+      it('should set an active transcription', function () {
+        transcriptionsStore.setActiveTranscription(1)
+        expect(transcriptionsStore.activeTranscriptionIndex).toBe(1)
+      })
+
+      it('should edit the text object', function () {
+        const textObject = [mockReduction]
+        transcriptionsStore.setTextObject([mockReduction])
+        expect(transcriptionsStore.current.text.get('frame0')).toEqual(textObject)
+      })
+
+      it('should not insert an invalid transcription', function () {
+        expect(transcriptionsStore.all.size).toBe(1)
+        transcriptionsStore.setTranscription(1)
+        expect(consoleSpy).toHaveBeenCalled()
+        expect(transcriptionsStore.all.size).toBe(1)
+      })
+
+      it('should save a transcription', function () {
+        transcriptionsStore.saveTranscription()
+        expect(patchToveSpy).toHaveBeenCalled()
+      })
+
+      it('should update the flagged attribute', function () {
+        expect(transcriptionsStore.current.flagged).toBe(false)
+        transcriptionsStore.setTextObject([mockReduction])
+        transcriptionsStore.checkForFlagUpdate()
+        expect(patchToveSpy).toHaveBeenCalled()
+        expect(transcriptionsStore.current.flagged).toBe(true)
+      })
+
+      it('should update the approval status', async function () {
+        await transcriptionsStore.updateApproval(false)
+        expect(transcriptionsStore.readyForReview).toBe(true)
+      })
+
+      it('should toggle off the approval status', async function () {
+        await transcriptionsStore.updateApproval(true)
+        expect(transcriptionsStore.readyForReview).toBe(false)
+      })
+
+      describe('when deleting a line', function () {
+        it('should not proceed without an active transcription', function () {
+          const current = transcriptionsStore.current.text.get('frame0')
+          expect(current.length).toBe(1)
+          transcriptionsStore.deleteCurrentLine()
+          expect(current.length).toBe(1)
+          expect(patchToveSpy).not.toHaveBeenCalled()
+        })
+
+        it('should delete a line', function () {
+          transcriptionsStore.setActiveTranscription(0)
+          const current = transcriptionsStore.current.text.get('frame0')
+          expect(current.length).toBe(1)
+          transcriptionsStore.deleteCurrentLine()
+          expect(current.length).toBe(0)
+          expect(patchToveSpy).toHaveBeenCalled()
+        })
+      })
     })
 
-    it('should select a single transcription', function () {
-      const transcription = transcriptionsStore.createTranscription(simpleTranscription)
-      expect(transcriptionsStore.current).toEqual(transcription)
-    })
-
-    it('should set an active transcription', function () {
-      transcriptionsStore.setActiveTranscription(1)
-      expect(transcriptionsStore.activeTranscriptionIndex).toBe(1)
-    })
-
-    it('should update the approval status', async function () {
-      await transcriptionsStore.updateApproval(false)
-      expect(transcriptionsStore.readyForReview).toBe(true)
-    })
-
-    it('should edit the text object', function () {
-      const textObject = [mockReduction]
-      transcriptionsStore.setTextObject([mockReduction])
-      expect(transcriptionsStore.current.text.get('frame0')).toEqual(textObject)
+    describe('failure state', function () {
+      it('should register an error', async function () {
+        rootStore = AppStore.create({ client: { tove: failedToveStub }})
+        transcriptionsStore = rootStore.transcriptions
+        await transcriptionsStore.selectTranscription(1)
+        expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
+        expect(consoleSpy).toHaveBeenCalled()
+      })
     })
   })
-
-    // it('should fetch transcriptions for a subject', async function () {
-    //   await transcriptionsStore.selectTranscription(1)
-    //   const transcription = transcriptionsStore.createTranscription(simpleTranscription)
-    //   expect(transcriptionsStore.current).toEqual(transcription)
-    // })
-
-    // it('should return the current transcription state', async function () {
-    //   await transcriptionsStore.selectTranscription(1)
-    //   expect(transcriptionsStore.approved).toBe(false)
-    //   expect(transcriptionsStore.title).toBe("1")
-    // })
-    //
-    // it('should set the active transcription', function () {
-    //   transcriptionsStore.setActiveTranscription(5)
-    //   expect(transcriptionsStore.activeTranscriptionIndex).toBe(5)
-    // })
-    //
-    // it('should delete a transcription line', async function () {
-    //   await transcriptionsStore.selectTranscription(1)
-    //   transcriptionsStore.setTextObject([mockReduction])
-    //   const current = transcriptionsStore.current.text.get('frame0')
-    //   expect(current.length).toBe(1)
-    //   transcriptionsStore.setActiveTranscription(0)
-    //   transcriptionsStore.deleteCurrentLine()
-    //   expect(current.length).toBe(0)
-    //   expect(patchToveSpy).toHaveBeenCalled()
-    // })
-    //
-    // it('should not delete an inactive transcription line', async function () {
-    //   await transcriptionsStore.selectTranscription(1)
-    //   transcriptionsStore.setTextObject([mockReduction])
-    //   const current = transcriptionsStore.current.text.get('frame0')
-    //   expect(current.length).toBe(1)
-    //   transcriptionsStore.deleteCurrentLine()
-    //   expect(patchToveSpy).not.toHaveBeenCalled()
-    // })
-
-  //   describe('after selecting a transcription', function () {
-  //     beforeEach(async function () {
-  //       await transcriptionsStore.selectTranscription(1)
-  //     })
-  //
-  //     it('should select the correct transcription', async function () {
-  //       const transcription = transcriptionsStore.createTranscription(simpleTranscription)
-  //       expect(transcriptionsStore.current).toEqual(transcription)
-  //     })
-  //
-  //     it('should edit the text object', async function () {
-  //       const textObject = [mockReduction]
-  //       transcriptionsStore.setTextObject([mockReduction])
-  //       expect(transcriptionsStore.current.text.get('frame0')).toEqual(textObject)
-  //     })
-  //
-  //     it('should save a transcription', async function () {
-  //       await transcriptionsStore.saveTranscription()
-  //       expect(patchToveSpy).toHaveBeenCalled()
-  //     })
-  //
-  //     it('should update the flagged attribute', function () {
-  //       expect(transcriptionsStore.current.flagged).toBe(false)
-  //       transcriptionsStore.setTextObject([mockReduction])
-  //       transcriptionsStore.checkForFlagUpdate()
-  //       expect(patchToveSpy).toHaveBeenCalled()
-  //       expect(transcriptionsStore.current.flagged).toBe(true)
-  //     })
-  //   })
-  // })
-
-  // describe('success state fetching single transcription', function () {
-  //   it('should fetch a single transcription', async function () {
-  //     rootStore = AppStore.create({
-  //       client: { tove: singleTranscriptionStub },
-  //       groups: {
-  //         current: {
-  //           display_name: 'GROUP_1'
-  //         }
-  //       },
-  //       subject: {
-  //         index: 0
-  //       },
-  //       workflows: {
-  //         all: { 1: { id: '1' } },
-  //         current: '1'
-  //       }
-  //     })
-  //     transcriptionsStore = rootStore.transcriptions
-  //     const returnValue = await transcriptionsStore.fetchTranscription('1')
-  //     expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.READY)
-  //     expect(returnValue).toBeDefined()
-  //   })
-  //
-  //   it('should be able to update an approval state', async function () {
-  //     await transcriptionsStore.selectTranscription(1)
-  //     await transcriptionsStore.updateApproval(false)
-  //     expect(transcriptionsStore.readyForReview).toBe(true)
-  //   })
-  // })
-
-  // describe('failure state', function () {
-  //   beforeEach(function() {
-  //     rootStore = AppStore.create({
-  //       client: { tove: failedToveStub },
-  //       groups: {
-  //         current: {
-  //           display_name: 'GROUP_1'
-  //         }
-  //       }
-  //     })
-  //   })
-  //
-  //   it('should not set a workflow if give the wrong info', function () {
-  //     transcriptionsStore = rootStore.transcriptions
-  //     expect(transcriptionsStore.all.size).toBe(0)
-  //     transcriptionsStore.setTranscription(1)
-  //     expect(transcriptionsStore.all.size).toBe(0)
-  //   })
-  //
-  //   it('should handle an error when fetching transcriptions', async function () {
-  //     transcriptionsStore = rootStore.transcriptions
-  //     await transcriptionsStore.fetchTranscriptions()
-  //     expect(transcriptionsStore.error).toBe(error.message)
-  //     expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
-  //   })
-  //
-  //   it('should handle an error when fetching a transcription', async function () {
-  //     transcriptionsStore = rootStore.transcriptions
-  //     await transcriptionsStore.fetchTranscription('1')
-  //     expect(transcriptionsStore.error).toBe(error.message)
-  //     expect(transcriptionsStore.asyncState).toBe(ASYNC_STATES.ERROR)
-  //   })
 })


### PR DESCRIPTION
Closes #90 

In attempting to save the original transcriber, I had to do more mapping of extracts and reductions. In doing so, I found many opportunities for refactoring. This PR refactors many of those mapping functions while also rewriting the `TranscriptionsStore` tests as they were getting a bit unwieldy and needed to be straightened up some.