### PR TITLE
Add Workflow Id to Transcriptions Query

### DIFF
--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -116,9 +116,10 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     self.reset()
     self.page = page
     const groupName = getRoot(self).groups.title
-    if (!groupName) return
+    const workflow = getRoot(self).workflows.current.id
+    if (!groupName || !workflow) return
     const searchQuery = getRoot(self).search.getSearchQuery()
-    yield self.retrieveTranscriptions(`/transcriptions?filter[group_id_eq]=${groupName}&page[number]=${self.page + 1}${searchQuery}`)
+    yield self.retrieveTranscriptions(`/transcriptions?filter[group_id_eq]=${groupName}&filter[workflow_id_eq]=${workflow}&page[number]=${self.page + 1}${searchQuery}`)
   }
 
   function reset() {

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -231,6 +231,10 @@ describe('TranscriptionsStore', function () {
           current: {
             display_name: 'GROUP_1'
           }
+        },
+        workflows: {
+          all: { 1: { id: '1' } },
+          current: '1'
         }
       })
     })


### PR DESCRIPTION
Closes #102 

This PR adds the current workflow ID to the query when fetching for transcriptions. This will help the backend more accurately return relevant transcriptions.