### PR TITLE
Data downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@zooniverse/grommet-theme": "^2.1.0",
     "babel-preset-react-app": "^7.0.0",
     "coveralls": "^3.0.7",
+    "downloadjs": "^1.4.7",
     "formik": "^1.5.8",
     "frisbee": "^3.1.0",
     "graphql-request": "^1.8.2",

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -426,6 +426,7 @@ exports[`Storyshots DownloadDataModal Default 1`] = `
           aria-label="Download Subject Data"
           className="StyledButton-sc-323bzc-0 jfbKsv"
           onBlur={[Function]}
+          onClick={[Function]}
           onFocus={[Function]}
           onMouseOut={[Function]}
           onMouseOver={[Function]}

--- a/src/components/Modals/DownloadDataModal/DownloadDataModal.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModal.js
@@ -8,6 +8,7 @@ export default function DownloadDataModal({
   approved,
   entireGroup,
   onClose,
+  onDownload,
   transcriptionCount
 }) {
   const text = entireGroup ? 'Download approved subject set data' : 'Download subject data'
@@ -45,8 +46,10 @@ export default function DownloadDataModal({
         <Button
           a11yTitle="Download Subject Data"
           label={<Text size='small'>DOWNLOAD</Text>}
+          onClick={onDownload}
           plain
         />
+        <a href="https://tove-staging.zooniverse.org/transcriptions/export_group?group_id=TEST1&workflow_id=3085">download via link</a>
       </Box>
     </Box>
   )
@@ -56,6 +59,7 @@ DownloadDataModal.propTypes = {
   approved: number,
   entireGroup: bool,
   onClose: func,
+  onDownload: func,
   transcriptionCount: number
 }
 
@@ -63,5 +67,6 @@ DownloadDataModal.defaultProps = {
   approved: number,
   entireGroup: false,
   onClose: () => {},
+  onDownload: () => {},
   transcriptionCount: 0
 }

--- a/src/components/Modals/DownloadDataModal/DownloadDataModal.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModal.js
@@ -49,7 +49,6 @@ export default function DownloadDataModal({
           onClick={onDownload}
           plain
         />
-        <a href="https://tove-staging.zooniverse.org/transcriptions/export_group?group_id=TEST1&workflow_id=3085">download via link</a>
       </Box>
     </Box>
   )

--- a/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.js
@@ -6,7 +6,10 @@ import DownloadDataModal from './DownloadDataModal'
 export default function DownloadDataModalContainer({ entireGroup }) {
   const store = React.useContext(AppContext)
   const onClose = () => store.modal.toggleModal('')
-  const onDownload = () => store.client.downloadData(entireGroup)
+  const onDownload = () => {
+    store.client.downloadData(entireGroup)
+    onClose()
+  }
 
 
   return (

--- a/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.js
@@ -6,12 +6,15 @@ import DownloadDataModal from './DownloadDataModal'
 export default function DownloadDataModalContainer({ entireGroup }) {
   const store = React.useContext(AppContext)
   const onClose = () => store.modal.toggleModal('')
+  const onDownload = () => store.client.downloadData(entireGroup)
+
 
   return (
     <DownloadDataModal
       approved={store.transcriptions.approvedCount}
       entireGroup={entireGroup}
       onClose={onClose}
+      onDownload={onDownload}
       transcriptionCount={store.transcriptions.all.size}
     />
   )

--- a/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.spec.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.spec.js
@@ -3,8 +3,12 @@ import React from 'react'
 import DownloadDataModalContainer from './DownloadDataModalContainer'
 
 let wrapper
+const downloadDataSpy = jest.fn()
 const toggleModalSpy = jest.fn()
 const contextValues = {
+  client: {
+    downloadData: downloadDataSpy
+  },
   modal: {
     toggleModal: toggleModalSpy
   },
@@ -22,12 +26,20 @@ describe('Component > DownloadDataModalContainer', function () {
     wrapper = shallow(<DownloadDataModalContainer />);
   })
 
+  afterEach(() => jest.clearAllMocks());
+
   it('should render without crashing', function () {
     expect(wrapper).toBeDefined()
   })
 
   it('should call toggleModal on child onClose', function () {
     wrapper.props().onClose()
+    expect(toggleModalSpy).toHaveBeenCalledWith('')
+  })
+
+  it('should call toggleModal on child onClose', function () {
+    wrapper.props().onDownload()
+    expect(downloadDataSpy).toHaveBeenCalled()
     expect(toggleModalSpy).toHaveBeenCalledWith('')
   })
 })

--- a/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.spec.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModalContainer.spec.js
@@ -37,7 +37,7 @@ describe('Component > DownloadDataModalContainer', function () {
     expect(toggleModalSpy).toHaveBeenCalledWith('')
   })
 
-  it('should call toggleModal on child onClose', function () {
+  it('should call downloadData when download clicked', function () {
     wrapper.props().onDownload()
     expect(downloadDataSpy).toHaveBeenCalled()
     expect(toggleModalSpy).toHaveBeenCalledWith('')

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -6,7 +6,7 @@ import download from 'downloadjs'
 const ClientStore = types.model('ClientStore', {
   bearerToken: types.optional(types.string, ''),
   tove: types.optional(types.frozen({}), null),
-  toveCSV: types.optional(types.frozen({}), null)
+  toveZip: types.optional(types.frozen({}), null)
 }).actions(self => ({
   initialize: () => {
     self.tove = new Frisbee({
@@ -17,7 +17,7 @@ const ClientStore = types.model('ClientStore', {
       },
       mode: 'cors'
     })
-    self.toveCSV = new Frisbee({
+    self.toveZip = new Frisbee({
       baseURI: config.tove,
       headers: {
         'Accept': 'application/zip',
@@ -39,7 +39,7 @@ const ClientStore = types.model('ClientStore', {
     const filename = isEntireGroup ? `${currentGroup}_export` : `${currentTranscription}_export`
 
       try {
-        yield self.toveCSV.get(query).then(response => response.blob())
+        yield self.toveZip.get(query).then(response => response.blob())
           .then(blob => download(blob, `${filename}.zip`))
       } catch (error) {
         console.log(error);
@@ -48,7 +48,7 @@ const ClientStore = types.model('ClientStore', {
 
   setBearerToken: (token) => {
     self.tove.jwt(token)
-    self.toveCSV.jwt(token)
+    self.toveZip.jwt(token)
   }
 }))
 

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -1,10 +1,12 @@
-import { getRoot, types } from 'mobx-state-tree'
+import { flow, getRoot, types } from 'mobx-state-tree'
 import Frisbee from 'frisbee'
 import { config } from 'config'
+import download from 'downloadjs'
 
 const ClientStore = types.model('ClientStore', {
   bearerToken: types.optional(types.string, ''),
-  tove: types.optional(types.frozen({}), null)
+  tove: types.optional(types.frozen({}), null),
+  toveCSV: types.optional(types.frozen({}), null)
 }).actions(self => ({
   initialize: () => {
     self.tove = new Frisbee({
@@ -15,18 +17,40 @@ const ClientStore = types.model('ClientStore', {
       },
       mode: 'cors'
     })
+    self.toveCSV = new Frisbee({
+      baseURI: config.tove,
+      headers: {
+        'Accept': 'application/zip',
+        'Access-Control-Expose-Headers': 'Content-Disposition',
+        'Content-Type': 'application/zip',
+        'Content-Disposition': 'attachment; filename="export.zip"'
+      },
+      mode: 'cors',
+      // This is necessary for the Frisbee api to convert the response to a blob
+      // Otherwise, the response is always locked when trying to download the response stream
+      raw: true
+    })
   },
 
-  downloadData: (isEntireGroup) => {
+  downloadData: flow(function * downloadData(isEntireGroup) {
     const currentGroup = getRoot(self).groups.title
     const currentTranscription = getRoot(self).transcriptions.title
     const currentWorkflow = getRoot(self).workflows.id
-    return isEntireGroup ? `/transcriptions/export_group?group_id=${currentGroup}&workflow_id=${currentWorkflow}`
+    const query = isEntireGroup ? `/transcriptions/export_group?group_id=${currentGroup}&workflow_id=${currentWorkflow}`
       : `/transcriptions/${currentTranscription}/export`
-  },
+    const filename = isEntireGroup ? `${currentGroup}_export` : `${currentTranscription}_export`
+
+      try {
+        yield self.toveCSV.get(query).then(response => response.blob())
+          .then(blob => download(blob, filename))
+      } catch (error) {
+        console.log(error);
+      }
+  }),
 
   setBearerToken: (token) => {
     self.tove.jwt(token)
+    self.toveCSV.jwt(token)
   }
 }))
 

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -1,4 +1,4 @@
-import { types } from 'mobx-state-tree'
+import { getRoot, types } from 'mobx-state-tree'
 import Frisbee from 'frisbee'
 import { config } from 'config'
 
@@ -15,6 +15,14 @@ const ClientStore = types.model('ClientStore', {
       },
       mode: 'cors'
     })
+  },
+
+  downloadData: (isEntireGroup) => {
+    const currentGroup = getRoot(self).groups.title
+    const currentTranscription = getRoot(self).transcriptions.title
+    const currentWorkflow = getRoot(self).workflows.id
+    return isEntireGroup ? `/transcriptions/export_group?group_id=${currentGroup}&workflow_id=${currentWorkflow}`
+      : `/transcriptions/${currentTranscription}/export`
   },
 
   setBearerToken: (token) => {

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -42,7 +42,7 @@ const ClientStore = types.model('ClientStore', {
 
       try {
         yield self.toveCSV.get(query).then(response => response.blob())
-          .then(blob => download(blob, filename))
+          .then(blob => download(blob, `${filename}.zip`))
       } catch (error) {
         console.log(error);
       }

--- a/src/store/ClientStore.js
+++ b/src/store/ClientStore.js
@@ -21,9 +21,7 @@ const ClientStore = types.model('ClientStore', {
       baseURI: config.tove,
       headers: {
         'Accept': 'application/zip',
-        'Access-Control-Expose-Headers': 'Content-Disposition',
-        'Content-Type': 'application/zip',
-        'Content-Disposition': 'attachment; filename="export.zip"'
+        'Content-Type': 'application/zip'
       },
       mode: 'cors',
       // This is necessary for the Frisbee api to convert the response to a blob

--- a/src/store/ClientStore.spec.js
+++ b/src/store/ClientStore.spec.js
@@ -1,25 +1,63 @@
-import { ClientStore } from './ClientStore'
+import { AppStore } from './AppStore'
 
 let clientStore;
+let rootStore;
+let toveGetSpy = jest.fn().mockResolvedValue(new Response())
+const toveZipStub = { get: toveGetSpy }
 
 describe('ClientStore', function () {
   beforeEach(function() {
-    clientStore = ClientStore.create()
-    clientStore.initialize()
+    rootStore = AppStore.create({
+      client: { toveZip: toveZipStub },
+      groups: {
+        current: {
+          display_name: 'A_Group'
+        }
+      },
+      transcriptions: {
+        all: { 1: { id: '1', text: { 'frame0': [] }}
+      },
+        current: '1'
+      },
+      workflows: {
+        all: { 1: { id: '1' } },
+        current: '1'
+      }
+    })
+    clientStore = rootStore.client
+    console.log('root', rootStore.workflows.current);
   })
+
+  afterEach(() => jest.clearAllMocks());
 
   it('should run without crashing', function () {
     expect(clientStore).toBeDefined()
   })
 
   it('should initialize with the correct values', function () {
+    clientStore.initialize()
     expect(clientStore.tove.opts.headers.Accept).toBe('application/json')
     expect(clientStore.tove.opts.mode).toBe('cors')
   })
 
   it('should set the bearer token', function () {
+    clientStore.initialize()
     const token = 'a1b2c3d4'
     clientStore.setBearerToken(token)
     expect(clientStore.tove.opts.headers.Authorization).toBe(`Bearer ${token}`)
+  })
+
+  describe('downloading data', function () {
+    it('should download transcription data', function () {
+      const isEntireGroup = false
+      clientStore.downloadData(isEntireGroup)
+      expect(toveGetSpy).toHaveBeenCalledWith('/transcriptions/1/export')
+    })
+
+    it('should download export data', function () {
+      const isEntireGroup = true
+      clientStore.downloadData(isEntireGroup)
+      expect(toveGetSpy).toHaveBeenCalledWith('/transcriptions/export_group?group_id=A_Group&workflow_id=1')
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5159,6 +5159,11 @@ dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+downloadjs@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+  integrity sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=
+
 dtrace-provider@~0.8:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"


### PR DESCRIPTION
Closes #25 

Hooks up the UI to allow downloading group exports on the [transcriptions page](https://projects.invisionapp.com/d/#/console/17925240/375544496/preview) and single transcriptions on the [edit page](https://projects.invisionapp.com/d/#/console/17925240/371813753/preview).

- Downloading subject set data should download all approved subjects in a subject group into a .zip.
- Downloading a single subject from the edit page will also download a .zip for that individual subject.

**Note**: Transcription must be marked "approved" to download export