### PR TITLE
Allow user_ids array to be string or integer

### DIFF
--- a/src/store/Reduction.js
+++ b/src/store/Reduction.js
@@ -18,7 +18,7 @@ const Reduction = types.model('Reduction', {
   original_transcriber: types.optional(types.string, ''),
   seen: types.optional(types.boolean, false),
   slope_label: types.optional(types.integer, 0),
-  user_ids: types.array(types.maybeNull(types.integer))
+  user_ids: types.array(types.maybeNull(types.union(types.integer, types.string)))
 })
 .actions(self => ({
   setConsensusText: (text, isOriginalOption = false, originalTranscriber = '') => {


### PR DESCRIPTION
The `user_ids` array contains integers when coming from TOVE, but strings when reextracting. This PR adds some variability when storing those values