### PR TITLE
Fix UI Inconsistencies when Toggling Between Subjects

### DIFF
--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Box } from 'grommet'
 import styled from 'styled-components'
 import AppContext from 'store'
+import { observer } from 'mobx-react'
 import SubjectViewerHeader from './components/SubjectViewerHeader'
 import ImageTools from './components/ImageTools'
 import SVGView from './components/SVGView'
@@ -51,4 +52,4 @@ function SubjectViewerContainer() {
   )
 }
 
-export default SubjectViewerContainer
+export default observer(SubjectViewerContainer)

--- a/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
@@ -13,7 +13,8 @@ function findCurrentSrc(locations, index) {
 
 function SVGViewContainer () {
   const store = React.useContext(AppContext)
-  const disableInteraction = store.subjects.asyncState !== ASYNC_STATES.READY
+  const { asyncState } = store.subjects
+  const disableInteraction = asyncState !== ASYNC_STATES.READY
   const svgEl = React.useRef(null)
   const [img, setImg] = React.useState(new Image())
   const src = findCurrentSrc(store.subjects.current.locations, store.transcriptions.index)
@@ -55,9 +56,8 @@ function SVGViewContainer () {
     onLoad();
   }, [img, src, store.image])
 
-  console.log('loading', img);
   const transform = `scale(${store.image.scale}) translate(${store.image.translateX}, ${store.image.translateY}) rotate(${store.image.rotation})`
-  if (src.length === 0) return null;
+  if (src.length === 0 || asyncState !== ASYNC_STATES.READY) return null;
 
   return (
     <Box ref={svgEl} fill>

--- a/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
@@ -57,7 +57,7 @@ function SVGViewContainer () {
   }, [img, src, store.image])
 
   const transform = `scale(${store.image.scale}) translate(${store.image.translateX}, ${store.image.translateY}) rotate(${store.image.rotation})`
-  if (src.length === 0 || asyncState !== ASYNC_STATES.READY) return null;
+  if (src.length === 0 || disableInteraction) return null;
 
   return (
     <Box ref={svgEl} fill>

--- a/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
@@ -17,6 +17,8 @@ function SVGViewContainer () {
   const svgEl = React.useRef(null)
   const [img, setImg] = React.useState(new Image())
   const src = findCurrentSrc(store.subjects.current.locations, store.transcriptions.index)
+  const [naturalWidth, setNaturalWidth] = React.useState(0)
+  const [naturalHeight, setNaturalHeight] = React.useState(0)
 
   React.useEffect(() => {
     async function fetchImage() {
@@ -36,6 +38,8 @@ function SVGViewContainer () {
     async function getImageSize() {
       const image = await preLoad()
       const svg = svgEl.current || {}
+      setNaturalWidth(image.naturalWidth)
+      setNaturalHeight(image.naturalHeight)
       return {
         clientHeight: svg.clientHeight,
         clientWidth: svg.clientWidth,
@@ -51,7 +55,6 @@ function SVGViewContainer () {
     onLoad();
   }, [img, src, store.image])
 
-  const { naturalHeight, naturalWidth } = img
   const transform = `scale(${store.image.scale}) translate(${store.image.translateX}, ${store.image.translateY}) rotate(${store.image.rotation})`
   if (src.length === 0) return null;
 

--- a/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
@@ -55,6 +55,7 @@ function SVGViewContainer () {
     onLoad();
   }, [img, src, store.image])
 
+  console.log('loading', img);
   const transform = `scale(${store.image.scale}) translate(${store.image.translateX}, ${store.image.translateY}) rotate(${store.image.rotation})`
   if (src.length === 0) return null;
 

--- a/src/components/SubjectViewer/components/SVGView/SVGViewContainer.spec.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGViewContainer.spec.js
@@ -22,7 +22,7 @@ const contextValues = {
     translateY: 0
   },
   subjects: {
-    asyncState: ASYNC_STATES.IDLE,
+    asyncState: ASYNC_STATES.READY,
     current: {
       locations: [{
         image: 'www.test.com'
@@ -76,7 +76,7 @@ describe('Component > SVGViewContainer', function () {
   })
 
   it('should set the image size', function () {
-    expect(svg.props().height).toBe(200)
-    expect(svg.props().width).toBe(100)
+    expect(svg.props().height.naturalHeight).toBe(200)
+    expect(svg.props().width.naturalWidth).toBe(100)
   })
 })

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -27,8 +27,8 @@ function Editor ({ match }) {
 
   React.useEffect(() => {
     const setResources = async () => {
-      await store.getResources(match.params)
       await store.subjects.fetchSubject(match.params.subject)
+      await store.getResources(match.params)
     }
     setResources()
     store.transcriptions.setActiveTranscription()

--- a/src/store/SubjectStore.js
+++ b/src/store/SubjectStore.js
@@ -31,6 +31,7 @@ const SubjectStore = types.model('SubjectStore', {
     } catch (error) {
       console.warn(error);
       self.error = error.message
+      self.current = undefined
       self.asyncState = ASYNC_STATES.ERROR
     }
   }),


### PR DESCRIPTION
Closes #118 

Three main items are fixed here:

**Set the image width and height when changing subjects**: This resolves an error when seeing a valid subject, visiting an invalid subject and seeing nothing, and returning to a valid subject where you would still see the 0x0 dimensions from the invalid subject.

**Allow async state to render while loading image**: This previously wasn't visible unless a user hovered over the SVG image container.

**Clear out the previous subject when loading a new one**: Previously, the previous subject would be visible for a moment when visiting a new subject