### PR TITLE
Add Minimum Heights to Transcription Sections

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -675,7 +675,7 @@ exports[`Storyshots LineViewer Default 1`] = `
       className="StyledBox-sc-13pk1d4-0 biltor sc-jTzLTM kGoDGv"
     >
       <div
-        className="StyledBox-sc-13pk1d4-0 HtQTI"
+        className="StyledBox-sc-13pk1d4-0 dbskGW"
       >
         <div
           className="StyledBox-sc-13pk1d4-0 hFIMGw"
@@ -819,7 +819,7 @@ exports[`Storyshots LineViewer Default 1`] = `
           className="StyledBox-sc-13pk1d4-0 eDJfis"
         />
         <div
-          className="StyledBox-sc-13pk1d4-0 fkSDnI"
+          className="StyledBox-sc-13pk1d4-0 eVyzLf"
         >
           <div
             className="StyledBox-sc-13pk1d4-0 fWrrBh"
@@ -919,7 +919,7 @@ exports[`Storyshots LineViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 hwlrxd"
+        className="StyledBox-sc-13pk1d4-0 fFNGzj"
       >
         <div
           className="StyledBox-sc-13pk1d4-0 ekjAwv"

--- a/src/components/LineViewer/LineViewer.js
+++ b/src/components/LineViewer/LineViewer.js
@@ -58,7 +58,7 @@ function LineViewer ({
   return (
     <RelativeBox background='white' elevation='small' round='xsmall' width='large'>
       {showDeleteModal && <DeleteModal toggleModal={toggleDeleteModal} />}
-      <Box border='bottom' pad={{ top: 'xsmall', horizontal: 'xsmall' }}>
+      <Box border='bottom' height={{ min: '3em' }}  pad={{ top: 'xsmall', horizontal: 'xsmall' }}>
         <Box align='center' direction='row' justify='between'>
           <Box basis='80%'>
             <CapitalText size='0.6em' weight='bold'>Selected Transcription</CapitalText>
@@ -97,7 +97,7 @@ function LineViewer ({
               transcription={transcription}
             />)}
         </Box>
-        <Box border='top' gap='xsmall' margin={{ horizontal: 'small', bottom: 'xsmall' }} pad={{ top: 'xsmall' }}>
+        <Box border='top' gap='xsmall' height={{ min: '4em' }} margin={{ horizontal: 'small', bottom: 'xsmall' }} pad={{ top: 'xsmall' }}>
           <Box>
             <Box direction='row' gap='xsmall'>
               {!isViewer && (
@@ -139,7 +139,7 @@ function LineViewer ({
           )}
         </Box>
       </Box>
-      <Box direction='row' justify='between' margin={{ horizontal: 'xsmall', bottom: 'xsmall', top: '0.25em' }}>
+      <Box direction='row' height={{ min: '1.5em' }} justify='between' margin='xsmall'>
         {!isViewer && (
           <Box direction='row'>
             <Button margin={{ right: 'small' }}><CapitalText size='xsmall'>Add Line Below</CapitalText></Button>


### PR DESCRIPTION
Closes #115 

Takes care of issues with the transcription pane when too many transcriptions present. You can test this by going to a transcription with too many annotations for a line. 

This one should work:
**Project**: Anti-Slavery Testing
**Workflow**: Anti-Slavery Workflow 1
**Group**: TEST1
**Transcription**: 72815

Upon opening that transcription there should be a line on the table with 39 transcriptions that begins, "Mr that Oakes"
