### PR TITLE
Filmstrip Design Notes

### DIFF
--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -4,12 +4,24 @@ import { bool, func, number, string } from 'prop-types'
 import ThumbnailBorder from './ThumbnailBorder'
 
 export default function FilmstripThumbnail ({ disabled, index, isActive, rotationDegrees, selectImage, src }) {
+  const [isHover, onHover] = React.useState(false)
+
   return (
-      <Button disabled={disabled} margin='xsmall' onClick={() => selectImage(index)}>
+      <Button
+        disabled={disabled}
+        margin='xsmall'
+        onBlur={() => onHover(false)}
+        onClick={() => selectImage(index)}
+        onFocus={() => onHover(true)}
+        onMouseEnter={() => onHover(true)}
+        onMouseLeave={() => onHover(false)}
+      >
         <Box height='xsmall' width='xsmall'>
-          {isActive && (
-            <ThumbnailBorder rotationDegrees={rotationDegrees} />
-          )}
+          <ThumbnailBorder
+            isActive={isActive}
+            isHover={isHover}
+            rotationDegrees={rotationDegrees}
+          />
           <Image alt={`Subject Page ${index + 1}`} fit='cover' src={src} />
         </Box>
       </Button>

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
@@ -2,20 +2,24 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import { Button } from 'grommet'
 import FilmstripThumbnail from './FilmstripThumbnail'
-import ThumbnailBorder from './ThumbnailBorder'
 
-let selectImage
+const selectImage = jest.fn()
+const setStateSpy = jest.fn()
 let wrapper
 
 describe('Component > FilmstripViewer', function () {
   beforeEach(function() {
-    selectImage = jest.fn()
+    jest
+      .spyOn(React, 'useState')
+      .mockImplementation((init) => [init, setStateSpy])
     wrapper = shallow(
       <FilmstripThumbnail
         selectImage={selectImage}
         src={'www.testlocation.com'}
       />)
   })
+
+  afterEach(() => jest.clearAllMocks());
 
   it('renders without crashing', function () {
     expect(wrapper).toBeDefined()
@@ -27,20 +31,27 @@ describe('Component > FilmstripViewer', function () {
     expect(selectImage).toHaveBeenCalled()
   })
 
-  it('should not render a border when not active', function() {
-    const border = wrapper.find(ThumbnailBorder)
-    expect(border.length).toBe(0)
+  it('changes the isHover state on blur', function() {
+    const button = wrapper.find(Button).first()
+    button.simulate('blur')
+    expect(setStateSpy).toHaveBeenCalledWith(false)
   })
 
-  describe('when isActive set to true', function() {
-    it('should render a border around the subejct', function() {
-      wrapper = shallow(
-        <FilmstripThumbnail
-          isActive
-          src={'www.testlocation.com'}
-        />)
-      const border = wrapper.find(ThumbnailBorder)
-      expect(border.length).toBe(1)
-    })
+  it('changes the isHover state on mouse leave', function() {
+    const button = wrapper.find(Button).first()
+    button.simulate('mouseleave')
+    expect(setStateSpy).toHaveBeenCalledWith(false)
+  })
+
+  it('changes the isHover state on mouse enter', function() {
+    const button = wrapper.find(Button).first()
+    button.simulate('mouseenter')
+    expect(setStateSpy).toHaveBeenCalledWith(true)
+  })
+
+  it('changes the isHover state on focus', function() {
+    const button = wrapper.find(Button).first()
+    button.simulate('focus')
+    expect(setStateSpy).toHaveBeenCalledWith(true)
   })
 })

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
@@ -12,7 +12,7 @@ export default function ThumbnailBorder({ rotationDegrees }) {
   return (
     <StyledBox
       align='center'
-      border={{ color: 'blue', size: 'large' }}
+      border={{ color: 'brand', size: 'large' }}
       height='xsmall'
       justify='center'
       width='xsmall'>

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
@@ -3,7 +3,7 @@ import { Box, Text } from 'grommet'
 import styled from 'styled-components'
 import { bool, number } from 'prop-types'
 
-const StyledBox = styled(Box)`
+export const StyledBox = styled(Box)`
   background-color: rgba(0, 95, 255, 0.14);
   position: absolute;
 `

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
@@ -1,18 +1,26 @@
 import React from 'react'
 import { Box, Text } from 'grommet'
 import styled from 'styled-components'
-import { number } from 'prop-types'
+import { bool, number } from 'prop-types'
 
 const StyledBox = styled(Box)`
   background-color: rgba(0, 95, 255, 0.14);
   position: absolute;
 `
 
-export default function ThumbnailBorder({ rotationDegrees }) {
+export default function ThumbnailBorder({ isActive, isHover, rotationDegrees }) {
+  let border = {}
+  if (isHover) {
+    border = { color: 'brand', size: 'medium' }
+  }
+  if (isActive) {
+    border = { color: 'brand', size: 'large' }
+  }
+
   return (
     <StyledBox
       align='center'
-      border={{ color: 'brand', size: 'large' }}
+      border={border}
       height='xsmall'
       justify='center'
       width='xsmall'>
@@ -29,9 +37,13 @@ export default function ThumbnailBorder({ rotationDegrees }) {
 }
 
 ThumbnailBorder.propTypes = {
+  isActive: bool,
+  isHover: bool,
   rotationDegrees: number
 }
 
 ThumbnailBorder.defaultProps = {
+  isActive: false,
+  isHover: false,
   rotationDegrees: 0
 }

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.spec.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.spec.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 import { Text } from 'grommet'
-import ThumbnailBorder from './ThumbnailBorder'
+import ThumbnailBorder, { StyledBox } from './ThumbnailBorder'
 
 let wrapper
 
@@ -23,5 +23,21 @@ describe('Component > FilmstripViewer', function () {
     wrapper = shallow(<ThumbnailBorder rotationDegrees={90} />)
     const degrees = wrapper.find(Text).length
     expect(degrees).toBe(1)
+  })
+
+  describe('when hovered', function () {
+    it('should set the correct border', function () {
+      wrapper = shallow(<ThumbnailBorder isHover />)
+      const box = wrapper.find(StyledBox).first()
+      expect(box.props().border.size).toBe('medium')
+    })
+  })
+
+  describe('when active', function () {
+    it('should set the correct border', function () {
+      wrapper = shallow(<ThumbnailBorder isActive />)
+      const box = wrapper.find(StyledBox).first()
+      expect(box.props().border.size).toBe('large')
+    })
   })
 })


### PR DESCRIPTION
Takes care of the "All Pages" (Filmstrip Viewer) notes from #110 

- Capitalized the word "Pages" in the filmstrip viewer
- Adjusted the border of the filmstrip viewer
- Added hover states to the page images

<img width="1056" alt="Screen Shot 2020-03-23 at 8 46 23 AM" src="https://user-images.githubusercontent.com/14099077/77323147-cadb4d80-6ce2-11ea-872d-86a3ec5a4969.png">