### PR TITLE
Transcription Design Notes

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -726,7 +726,7 @@ exports[`Storyshots LineViewer Default 1`] = `
             <span
               className="StyledText-sc-1sadyjn-0 kutFY"
             >
-
+              
             </span>
           </div>
           <div
@@ -1040,12 +1040,12 @@ exports[`Storyshots MarkApproved Default 1`] = `
       />
       <span
         checked={false}
-        className="StyledCheckBox__StyledCheckBoxToggle-sc-1dbk5ju-4 hjGuWS"
+        className="StyledCheckBox__StyledCheckBoxToggle-sc-1dbk5ju-4 kOvstK"
         disabled={false}
       >
         <span
           checked={false}
-          className="StyledCheckBox__StyledCheckBoxKnob-sc-1dbk5ju-5 kGMNhu"
+          className="StyledCheckBox__StyledCheckBoxKnob-sc-1dbk5ju-5 GTsLr"
           disabled={false}
         />
       </span>
@@ -1616,7 +1616,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
       <span
         className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
-        This subject cannot be accessed because
+        This subject cannot be accessed because 
         <b>
           Erin Green
         </b>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -726,7 +726,7 @@ exports[`Storyshots LineViewer Default 1`] = `
             <span
               className="StyledText-sc-1sadyjn-0 kutFY"
             >
-              
+
             </span>
           </div>
           <div
@@ -907,7 +907,7 @@ exports[`Storyshots LineViewer Default 1`] = `
               className="StyledBox-sc-13pk1d4-0 jUNXut"
             >
               <div
-                className="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 hlgLRt"
+                className="StyledTextInput__StyledTextInputContainer-sc-1x30a0s-1 VFomL"
               >
                 <input
                   autoComplete="off"
@@ -1016,6 +1016,7 @@ exports[`Storyshots MarkApproved Default 1`] = `
   <label
     checked={false}
     className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
+    disabled={false}
     onClick={[Function]}
   >
     <span
@@ -1026,10 +1027,12 @@ exports[`Storyshots MarkApproved Default 1`] = `
     <div
       checked={false}
       className="StyledBox-sc-13pk1d4-0 fdQGpV StyledCheckBox-sc-1dbk5ju-6 jXdLin"
+      disabled={false}
     >
       <input
         checked={false}
         className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dmrmuV"
+        disabled={false}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1037,11 +1040,13 @@ exports[`Storyshots MarkApproved Default 1`] = `
       />
       <span
         checked={false}
-        className="StyledCheckBox__StyledCheckBoxToggle-sc-1dbk5ju-4 kOvstK"
+        className="StyledCheckBox__StyledCheckBoxToggle-sc-1dbk5ju-4 hjGuWS"
+        disabled={false}
       >
         <span
           checked={false}
-          className="StyledCheckBox__StyledCheckBoxKnob-sc-1dbk5ju-5 GTsLr"
+          className="StyledCheckBox__StyledCheckBoxKnob-sc-1dbk5ju-5 kGMNhu"
+          disabled={false}
         />
       </span>
     </div>
@@ -1611,7 +1616,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
       <span
         className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
-        This subject cannot be accessed because 
+        This subject cannot be accessed because
         <b>
           Erin Green
         </b>
@@ -1679,6 +1684,7 @@ exports[`Storyshots SubjectViewer Default 1`] = `
           >
             <button
               className="StyledButton-sc-323bzc-0 jfbKsv"
+              disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -60,10 +60,10 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
                   </h6>
                 </div>
                 <div
-                  className="StyledBox-sc-13pk1d4-0 fWrrBh"
+                  className="StyledBox-sc-13pk1d4-0 dzunxD"
                 >
                   <h6
-                    className="sc-bZQynM sc-gzVnrw eESFhd"
+                    className="sc-bZQynM sc-gzVnrw goYdle"
                   >
                     Consensus Score
                   </h6>

--- a/src/components/AggregatedTranscriptions/AggregatedTranscriptionsContainer.js
+++ b/src/components/AggregatedTranscriptions/AggregatedTranscriptionsContainer.js
@@ -6,7 +6,7 @@ import AggregatedTranscriptions from './AggregatedTranscriptions'
 function AggregatedTranscriptionsContainer({ margin }) {
   const store = React.useContext(AppContext)
   const showOverlay = store.aggregations.showModal || store.transcriptions.approved
-  const showTranscription = store.transcriptions.activeTranscriptionIndex !== undefined
+  const showTranscription = store.transcriptions.isActive
 
   return (
     <AggregatedTranscriptions

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
@@ -17,7 +17,6 @@ const StyledText = styled('h6')`
 `
 
 const RightAlignText = styled(StyledText)`
-  margin-left: auto;
   text-align: end;
 `
 
@@ -40,7 +39,7 @@ function TranscriptionTable ({ data, isViewer, setActiveTranscription, setTextOb
         <Box>
           <StyledText>Flag</StyledText>
         </Box>
-        <Box>
+        <Box margin={{ left: 'auto' }}>
           <RightAlignText>Consensus Score</RightAlignText>
         </Box>
       </Box>

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
@@ -82,25 +82,25 @@ function TranscriptionTableRow({
         hover={isHover}
         onMouseUp={() => setActiveTranscription(index)}>
         <MoveBox
-          basis='4%'
           hover={isHover}
           isViewer={isViewer}
           onMouseUp={(e) => stopEvents(e)}
           pad='0.2em'
+          basis='5%'
         >
           {!isViewer && (
-            <QuietBox>
-              <Menu color={hamburgerColor} size='xsmall' />
+            <QuietBox align='center'>
+              <Menu color={hamburgerColor} size='0.75em' />
             </QuietBox>
           )}
         </MoveBox>
-        <QuietBox basis='76%'>
+        <QuietBox basis='72%'>
           <Text>{datum.edited_consensus_text || datum.consensus_text}</Text>
         </QuietBox>
         <QuietBox basis='10%'>
           <Flags datum={datum} />
         </QuietBox>
-        <QuietBox align='end' basis='10%' pad={{ right: '0.25em' }}>
+        <QuietBox align='end' basis='13%' pad={{ right: '0.25em' }}>
           {datum.edited_consensus_text ? (
             <Text>Edited</Text>
           ) : (

--- a/src/components/Badge/BadgeContainer.js
+++ b/src/components/Badge/BadgeContainer.js
@@ -8,7 +8,7 @@ function BadgeContainer ({ onAbout }) {
   const [isOpen, setOpen] = React.useState(false)
   const user = store.auth.user
 
-  const disabled = store.aggregations.showModal
+  const disabled = store.aggregations.showModal || store.transcriptions.isActive
   const name = user && user.display_name
   const signOut = store.auth.logout
   const src = user && user.avatar_src

--- a/src/components/Badge/BadgeContainer.spec.js
+++ b/src/components/Badge/BadgeContainer.spec.js
@@ -20,6 +20,9 @@ const contextValues = {
   projects: {
     role: 'Researcher'
   },
+  transcriptions: {
+    isActive: false
+  }
 }
 
 describe('Component > BadgeContainer', function () {

--- a/src/components/EditorHeader/EditorHeaderContainer.js
+++ b/src/components/EditorHeader/EditorHeaderContainer.js
@@ -33,7 +33,7 @@ function getHeaderTools(path, isViewer = false) {
 function EditorHeaderContainer({ history }) {
   const store = React.useContext(AppContext)
   const buttons = getHeaderTools(history.location.pathname, store.projects.isViewer)
-  const disabled = store.aggregations.showModal || store.transcriptions.approved
+  const disabled = store.aggregations.showModal || store.transcriptions.approved || store.transcriptions.isActive
   const onAbout = routeMatcher(history.location.pathname, ABOUT_PATH)
   const showMetadata = routeMatcher(history.location.pathname, EDIT_PATH)
 

--- a/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.js
@@ -13,7 +13,7 @@ function UndoButtonContainer({ disabled }) {
 
   return (
     <HeaderButton
-      disabled={disableUndo}
+      disabled={disableUndo && !store.transcriptions.isActive}
       icon={<FontAwesomeIcon color='#555555' icon={faRedo} size='xs' />}
       label='Undo'
       onClick={onUndo}

--- a/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApproved.js
@@ -10,12 +10,13 @@ const CapitalText = styled(Text)`
   text-transform: uppercase;
 `
 
-function MarkApproved ({ checked, isAdmin, onChange }) {
+function MarkApproved ({ checked, disabled, isAdmin, onChange }) {
   const innerText = isAdmin ? 'Mark As Approved' : 'Ready For Review'
 
   return (
     <CheckBox
       checked={checked}
+      disabled={disabled}
       label={<CapitalText color='#5C5C5C'>{innerText}</CapitalText>}
       onChange={onChange}
       reverse
@@ -26,12 +27,14 @@ function MarkApproved ({ checked, isAdmin, onChange }) {
 
 MarkApproved.propTypes = {
   checked: bool,
+  disabled: bool,
   isAdmin: bool,
   onChange: func
 }
 
 MarkApproved.defaultProps = {
   checked: false,
+  disabled: false,
   isAdmin: false,
   onChange: () => {}
 }

--- a/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.js
+++ b/src/components/EditorHeader/components/MarkApproved/MarkApprovedContainer.js
@@ -23,6 +23,7 @@ function MarkApprovedContainer() {
   return (
     <MarkApproved
       checked={isChecked}
+      disabled={store.transcriptions.isActive}
       isAdmin={store.projects.isAdmin}
       onChange={onChange}
     />

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.js
@@ -8,10 +8,11 @@ function MetadataButtonContainer() {
   const metadata = store.subjects.current && store.subjects.current.metadata
   const id = store.subjects.current && store.subjects.current.id
   const status = store.transcriptions.current && store.transcriptions.current.status
+  const disabled = store.aggregations.showModal || store.transcriptions.isActive
 
   return (
     <MetadataButton
-      disabled={store.aggregations.showModal}
+      disabled={disabled}
       id={id}
       metadata={metadata}
       status={status}

--- a/src/components/EditorHeader/components/MoreButton/MoreButtonContainer.js
+++ b/src/components/EditorHeader/components/MoreButton/MoreButtonContainer.js
@@ -6,7 +6,7 @@ import MoreButton from './MoreButton'
 export default function MoreButtonContainer() {
   const store = React.useContext(AppContext)
   const [isOpen, setOpen] = React.useState(false)
-  const disabled = store.aggregations.showModal
+  const disabled = store.aggregations.showModal || store.transcriptions.isActive
   const disableEditingAggregations = store.transcriptions.approved
   const toggleDownload = () => store.modal.toggleModal(MODALS.DOWNLOAD_SUBJECT)
 

--- a/src/components/EditorHeader/components/Title/Title.js
+++ b/src/components/EditorHeader/components/Title/Title.js
@@ -28,6 +28,7 @@ function Title({ history, match, onEditor }) {
   }
 
   const store = React.useContext(AppContext)
+  const disabled = store.aggregations.showModal || store.transcriptions.isActive
   const project = store.projects.title || ''
   const workflow = store.workflows.title || ''
   const group = store.groups.title || ''
@@ -63,7 +64,7 @@ function Title({ history, match, onEditor }) {
               <Button
                 key={`SUB_HEADER_${i}`}
                 a11yTitle={sub.to}
-                disabled={store.aggregations.showModal}
+                disabled={disabled}
                 label={<CapitalText key={`SUB_HEADER_${i}`} color='#5C5C5C'>{`${sub.title} ${removeSlash ? '' : '/'}`}</CapitalText>}
                 onClick={() => routeTo(sub.path)}
                 plain

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -6,7 +6,7 @@ import FilmstripViewer from './FilmstripViewer'
 function FilmstripViewerContainer({ images }) {
   const [isOpen, setOpen] = React.useState(true)
   const store = React.useContext(AppContext)
-  const disabled = store.aggregations.showModal
+  const disabled = store.aggregations.showModal || store.transcriptions.isActive
   const selectImage = (id) => {
     store.image.reset()
     store.transcriptions.setActiveTranscription()

--- a/src/components/LineViewer/LineViewerContainer.js
+++ b/src/components/LineViewer/LineViewerContainer.js
@@ -46,11 +46,16 @@ function LineViewerContainer({ isLoaded }) {
 
   React.useEffect(() => {
     localStore.loadTranscription(false)
-    if (store.transcriptions.parsedExtracts && transcriptionIndex !== undefined) {
+    if (store.transcriptions.parsedExtracts && store.transcriptions.isActive) {
       localStore.setTranscriptionOptions(store.transcriptions.parsedExtracts[transcriptionIndex])
     }
     localStore.loadTranscription(true)
-  }, [localStore, store.transcriptions.parsedExtracts, transcriptionIndex])
+  }, [
+    localStore,
+    store.transcriptions.isActive,
+    store.transcriptions.parsedExtracts,
+    transcriptionIndex
+  ])
 
   if (!localStore.isLoaded) return null
 

--- a/src/components/LineViewer/LineViewerContainer.spec.js
+++ b/src/components/LineViewer/LineViewerContainer.spec.js
@@ -31,6 +31,7 @@ const contextValues = {
     activeTranscriptionIndex: 0,
     current: currentTranscription,
     index: 0,
+    isActive: true,
     parsedExtracts: [[{}]],
     setActiveTranscription: setActiveTranscriptionSpy
   }

--- a/src/components/LineViewer/components/TranscriptionLine.js
+++ b/src/components/LineViewer/components/TranscriptionLine.js
@@ -54,13 +54,10 @@ function TranscriptionLine ({ isViewer, selectedItem, setItem, transcription, in
       </Box>
       <Box direction='row' gap='xxsmall' margin={{ left: '3em' }} wrap>
         <ItalicText>{writeDate(transcription.time)}</ItalicText>
-        <Text>&#8226;</Text>
         <ItalicText>{timeString}</ItalicText>
-        <Text>&#8226;</Text>
         <ItalicText size='xsmall'>{transcription.user}</ItalicText>
         {transcription.goldStandard && (
-          <Box direction='row' gap='xxsmall'>
-            <Text>&#8226;</Text>
+          <Box direction='row'>
             <ItalicText>Gold Standard</ItalicText>
           </Box>
         )}

--- a/src/components/LineViewer/theme.js
+++ b/src/components/LineViewer/theme.js
@@ -34,7 +34,7 @@ const theme = {
       extend: props => `
         input {
           font-style: italic;
-          padding: 0.2em;
+          padding: 0.4em;
         }
       `
     }

--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -43,7 +43,7 @@ function SubjectViewerContainer() {
         <AbsoluteBox fill>
           <AsyncMessages error={store.subjects.error} subjectState={store.subjects.asyncState} />
           <ToolsBox>
-            {showTools && <ImageTools />}
+            {showTools && !store.transcriptions.isActive && <ImageTools />}
           </ToolsBox>
         </AbsoluteBox>
         <SVGView />

--- a/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeader.js
+++ b/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeader.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Box, Button, Text } from 'grommet'
 import { bool, func } from 'prop-types'
 
-export default function SubjectViewerHeader({ linesVisible, toggleLineVisibility }) {
+export default function SubjectViewerHeader({ disabled, linesVisible, toggleLineVisibility }) {
   const text = linesVisible ? 'HIDE ALL LINES' : 'VIEW ALL LINES'
 
   return (
@@ -11,6 +11,7 @@ export default function SubjectViewerHeader({ linesVisible, toggleLineVisibility
         <Text size='1em'>Original Subject</Text>
         <Box direction='row' gap='small'>
           <Button
+            disabled={disabled}
             label={<Text>{text}</Text>}
             onClick={toggleLineVisibility}
             plain
@@ -22,11 +23,13 @@ export default function SubjectViewerHeader({ linesVisible, toggleLineVisibility
 }
 
 SubjectViewerHeader.propTypes = {
+  disabled: bool,
   linesVisible: bool,
   toggleLineVisibility: func
 }
 
 SubjectViewerHeader.defaultProps = {
+  disabled: false,
   linesVisible: true,
   toggleLineVisibility: () => {}
 }

--- a/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeaderContainer.js
+++ b/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeaderContainer.js
@@ -9,6 +9,7 @@ function SubjectViewerHeaderContainer() {
 
   return (
     <SubjectViewerHeader
+      disabled={store.transcriptions.isActive}
       linesVisible={store.editor.linesVisible}
       toggleLineVisibility={toggleLineVisibility}
     />

--- a/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeaderContainer.spec.js
+++ b/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeaderContainer.spec.js
@@ -8,6 +8,9 @@ const contextValues = {
   editor: {
     linesVisible: true,
     toggleLineVisibility: toggleLineVisibilitySpy
+  },
+  transcriptions: {
+    isActive: false
   }
 }
 

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -35,7 +35,7 @@ function Editor ({ match }) {
     undoManager.clear()
   }, [match, store])
 
-  const disabled = store.aggregations.showModal || store.transcriptions.approved
+  const disabled = store.aggregations.showModal || store.transcriptions.approved || store.transcriptions.isActive
   const subject = store.subjects.current
   const locations = findLocations(subject)
   const direction = store.editor.layout

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -355,6 +355,10 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     return count;
   },
 
+  get isActive () {
+    return self.activeTranscriptionIndex !== undefined
+  },
+
   get readyForReview () {
     return !!(self.current && self.current.status === 'ready')
   },


### PR DESCRIPTION
Handles the "Transcribed Line Detail" and "Transcription Lines" items from issue #110 

- Enlarged the text input box
- Removed the bullets between user time, date, and username (when shown) of transcriptions
- Disabled all buttons when a transcription is open (when modal in image is open)
- Adjust spacing of each transcription on the modal
- Adjusted spacing between "flag" and "consensus text"

<img width="563" alt="Screen Shot 2020-03-23 at 8 49 30 AM" src="https://user-images.githubusercontent.com/14099077/77323494-594fcf00-6ce3-11ea-8126-1aafa937d02d.png">
