### PR TITLE
Interface Design Notes

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -17,10 +17,11 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
           className="StyledBox-sc-13pk1d4-0 ikTqht"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 byArxi"
+            className="StyledBox-sc-13pk1d4-0 dLbpnh"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR"
+              className="StyledText-sc-1sadyjn-0 bXoRNz"
+              size="1em"
             >
               Transcribed Text
             </span>
@@ -453,15 +454,16 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-cMljjf hwFcyK"
+      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-jWBwVP gkntHJ"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 cGDWft"
       >
         <span
-          className="StyledText-sc-1sadyjn-0 bmpSIR"
+          className="StyledText-sc-1sadyjn-0 bXoRNz"
+          size="1em"
         >
-          All pages
+          All Pages
         </span>
         <button
           className="StyledButton-sc-323bzc-0 jfbKsv"
@@ -477,7 +479,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
             className="StyledBox-sc-13pk1d4-0 jHQJnz"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP gxqauL"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-cvbbAY bWJQPb"
             >
               Collapse
                Filmstrip
@@ -605,7 +607,7 @@ exports[`Storyshots HeaderButtons MoreButton 1`] = `
         MORE
       </span>
       <svg
-        aria-label="FormUp"
+        aria-label="FormDown"
         className="StyledIcon-ofa7kd-0 iOkQrb"
         viewBox="0 0 24 24"
       >
@@ -614,7 +616,6 @@ exports[`Storyshots HeaderButtons MoreButton 1`] = `
           points="18 9 12 15 6 9"
           stroke="#000"
           strokeWidth="2"
-          transform="matrix(1 0 0 -1 0 24)"
         />
       </svg>
     </div>
@@ -648,15 +649,21 @@ exports[`Storyshots HeaderButtons UndoButton 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 iEoiXx"
       />
       <svg
-        aria-label="Refresh"
-        className="StyledIcon-ofa7kd-0 bJsvPT"
-        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="svg-inline--fa fa-redo fa-w-16 fa-xs "
+        color="#555555"
+        data-icon="redo"
+        data-prefix="fas"
+        focusable="false"
+        role="img"
+        style={Object {}}
+        viewBox="0 0 512 512"
+        xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M20,8 C18.5974037,5.04031171 15.536972,3 12,3 C7.02943725,3 3,7.02943725 3,12 C3,16.9705627 7.02943725,21 12,21 L12,21 C16.9705627,21 21,16.9705627 21,12 M21,3 L21,9 L15,9"
-          fill="none"
-          stroke="#000"
-          strokeWidth="2"
+          d="M500.33 0h-47.41a12 12 0 0 0-12 12.57l4 82.76A247.42 247.42 0 0 0 256 8C119.34 8 7.9 119.53 8 256.19 8.1 393.07 119.1 504 256 504a247.1 247.1 0 0 0 166.18-63.91 12 12 0 0 0 .48-17.43l-34-34a12 12 0 0 0-16.38-.55A176 176 0 1 1 402.1 157.8l-101.53-4.87a12 12 0 0 0-12.57 12v47.41a12 12 0 0 0 12 12h200.33a12 12 0 0 0 12-12V12a12 12 0 0 0-12-12z"
+          fill="currentColor"
+          style={Object {}}
         />
       </svg>
     </div>
@@ -719,7 +726,7 @@ exports[`Storyshots LineViewer Default 1`] = `
             <span
               className="StyledText-sc-1sadyjn-0 kutFY"
             >
-              
+
             </span>
           </div>
           <div
@@ -1030,11 +1037,11 @@ exports[`Storyshots MarkApproved Default 1`] = `
       />
       <span
         checked={false}
-        className="StyledCheckBox__StyledCheckBoxToggle-sc-1dbk5ju-4 hjGuWS"
+        className="StyledCheckBox__StyledCheckBoxToggle-sc-1dbk5ju-4 kOvstK"
       >
         <span
           checked={false}
-          className="StyledCheckBox__StyledCheckBoxKnob-sc-1dbk5ju-5 kGMNhu"
+          className="StyledCheckBox__StyledCheckBoxKnob-sc-1dbk5ju-5 GTsLr"
         />
       </span>
     </div>
@@ -1063,23 +1070,27 @@ exports[`Storyshots MetadataButton Default 1`] = `
         onMouseOver={[Function]}
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          className="svg-inline--fa fa-info-circle fa-w-16 "
-          data-icon="info-circle"
-          data-prefix="fas"
-          focusable="false"
-          role="img"
-          style={Object {}}
-          viewBox="0 0 512 512"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          className="StyledBox-sc-13pk1d4-0 esKdNL"
         >
-          <path
-            d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-            fill="currentColor"
+          <svg
+            aria-hidden="true"
+            className="svg-inline--fa fa-info fa-w-6 sc-kkGfuU iRTBUr"
+            data-icon="info"
+            data-prefix="fas"
+            focusable="false"
+            role="img"
             style={Object {}}
-          />
-        </svg>
+            viewBox="0 0 192 512"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 424.229h20V279.771H20c-11.046 0-20-8.954-20-20V212c0-11.046 8.954-20 20-20h112c11.046 0 20 8.954 20 20v212.229h20c11.046 0 20 8.954 20 20V492c0 11.046-8.954 20-20 20H20c-11.046 0-20-8.954-20-20v-47.771c0-11.046 8.954-20 20-20zM96 0C56.235 0 24 32.235 24 72s32.235 72 72 72 72-32.235 72-72S135.764 0 96 0z"
+              fill="currentColor"
+              style={Object {}}
+            />
+          </svg>
+        </div>
       </button>
     </div>
   </div>
@@ -1144,7 +1155,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
             className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
           />
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
           >
             Find a specific subject
           </span>
@@ -1162,7 +1173,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 iEMnku"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jDwBTQ elzxaP"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1230,7 +1241,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 bgTRhM"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jDwBTQ elzxaP"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1268,7 +1279,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
             />
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
             >
               Filter subject list by status
             </span>
@@ -1549,7 +1560,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="button"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
                 >
                   Close
                 </span>
@@ -1564,7 +1575,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="submit"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
                 >
                   Search
                 </span>
@@ -1598,9 +1609,9 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP ffvzpR"
       >
-        This subject cannot be accessed because 
+        This subject cannot be accessed because
         <b>
           Erin Green
         </b>
@@ -1610,7 +1621,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP ffvzpR"
       >
         For access, ask them to close their version.
       </span>
@@ -1658,7 +1669,8 @@ exports[`Storyshots SubjectViewer Default 1`] = `
           className="StyledBox-sc-13pk1d4-0 hFIMGw"
         >
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR"
+            className="StyledText-sc-1sadyjn-0 bXoRNz"
+            size="1em"
           >
             Original Subject
           </span>
@@ -1684,16 +1696,16 @@ exports[`Storyshots SubjectViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo jmYbgd"
+        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-csuQGl dlqfCR"
       >
         <div
-          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-hzDkRC gvqsPE"
+          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm bUdQZZ"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-Rmtcm kYmdDB"
+            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-gipzik gWRpcz"
           />
           <div
-            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-hzDkRC sc-jhAzac fZhiDl"
+            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-Rmtcm sc-bRBYWo dNnMia"
           />
         </div>
         <div
@@ -1757,7 +1769,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
       >
         By unapproving this subject, the subject's data will be unavailable for future downloads until re-marked as approved.
       </span>
@@ -1765,7 +1777,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
       >
         This action can be reversed at any time.
       </span>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -454,7 +454,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-jWBwVP gkntHJ"
+      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-jAaTju lEldS"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 cGDWft"
@@ -479,7 +479,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
             className="StyledBox-sc-13pk1d4-0 jHQJnz"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-cvbbAY bWJQPb"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf clSTOo"
             >
               Collapse
                Filmstrip
@@ -726,7 +726,7 @@ exports[`Storyshots LineViewer Default 1`] = `
             <span
               className="StyledText-sc-1sadyjn-0 kutFY"
             >
-
+              
             </span>
           </div>
           <div
@@ -1075,7 +1075,7 @@ exports[`Storyshots MetadataButton Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="svg-inline--fa fa-info fa-w-6 sc-kkGfuU iRTBUr"
+            className="svg-inline--fa fa-info fa-w-6 sc-eHgmQL tiSJc"
             data-icon="info"
             data-prefix="fas"
             focusable="false"
@@ -1155,7 +1155,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
             className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
           />
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
           >
             Find a specific subject
           </span>
@@ -1173,7 +1173,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 iEMnku"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jDwBTQ elzxaP"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jlyJG kcnAXP"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1241,7 +1241,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 bgTRhM"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jDwBTQ elzxaP"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jlyJG kcnAXP"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1279,7 +1279,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
             />
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
             >
               Filter subject list by status
             </span>
@@ -1560,7 +1560,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="button"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
                 >
                   Close
                 </span>
@@ -1575,7 +1575,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="submit"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju jhmhPS"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
                 >
                   Search
                 </span>
@@ -1609,9 +1609,9 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP ffvzpR"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
-        This subject cannot be accessed because
+        This subject cannot be accessed because 
         <b>
           Erin Green
         </b>
@@ -1621,7 +1621,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP ffvzpR"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         For access, ask them to close their version.
       </span>
@@ -1696,16 +1696,16 @@ exports[`Storyshots SubjectViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-csuQGl dlqfCR"
+        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-hzDkRC eniHZY"
       >
         <div
-          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm bUdQZZ"
+          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-jhAzac ZlZeV"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-gipzik gWRpcz"
+            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-bRBYWo cfFjGV"
           />
           <div
-            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-Rmtcm sc-bRBYWo dNnMia"
+            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-jhAzac sc-fBuWsC deBBpZ"
           />
         </div>
         <div
@@ -1769,7 +1769,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay yONTa"
       >
         By unapproving this subject, the subject's data will be unavailable for future downloads until re-marked as approved.
       </span>
@@ -1777,7 +1777,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay yONTa"
       >
         This action can be reversed at any time.
       </span>

--- a/src/components/AggregatedTranscriptions/AggregatedTranscriptions.js
+++ b/src/components/AggregatedTranscriptions/AggregatedTranscriptions.js
@@ -44,12 +44,13 @@ function AggregatedTranscriptions ({ margin, showOverlay, showTranscription }) {
     <StyledBox height='large'>
       <Box background='white' fill='vertical' margin={margin} round='xsmall'>
         <Box
+          align='center'
           border={{ color: 'light-5', side: 'bottom' }}
           direction='row'
           justify='between'
           pad={{ left: '1em', right: 'xsmall', bottom: 'xsmall', top: 'xsmall' }}
         >
-          <Text>Transcribed Text</Text>
+          <Text size='1em'>Transcribed Text</Text>
           <CapitalText size='xsmall'>Add Line</CapitalText>
         </Box>
         <OverflowBox fill='vertical'>

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -36,7 +36,7 @@ const DropLink = styled(Link)`
 `
 
 function Badge ({ disabled, isOpen, name, onAbout, role, setOpen, signOut, src }) {
-  const Icon = isOpen ? FormDown : FormUp
+  const Icon = isOpen ? FormUp : FormDown
 
   return (
     <Box align='center' direction='row' gap='xsmall'>

--- a/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/UndoButtonContainer.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Refresh } from 'grommet-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faRedo } from '@fortawesome/free-solid-svg-icons'
 import { undoManager } from 'store/AppStore'
 import { observer } from 'mobx-react'
 import AppContext from 'store'
@@ -13,7 +14,7 @@ function UndoButtonContainer({ disabled }) {
   return (
     <HeaderButton
       disabled={disableUndo}
-      icon={<Refresh color='#555555' size='small'/>}
+      icon={<FontAwesomeIcon color='#555555' icon={faRedo} size='xs' />}
       label='Undo'
       onClick={onUndo}
     />

--- a/src/components/EditorHeader/components/MarkApproved/theme.js
+++ b/src/components/EditorHeader/components/MarkApproved/theme.js
@@ -4,9 +4,11 @@ const theme = {
       light: 'white',
       dark: 'white'
     },
+
     toggle: {
       extend: ({ checked }) => `
         ${checked ? `background-color: #078F52;` : `background-color: #D8D8D8`}
+        border-width: 1px;
       `
     }
   }

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -10,7 +10,7 @@ import {
   Text
 } from 'grommet'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faInfoCircle, faTimesCircle } from '@fortawesome/free-solid-svg-icons'
+import { faInfo, faTimesCircle } from '@fortawesome/free-solid-svg-icons'
 import { bool, number, shape, string } from 'prop-types'
 import styled from 'styled-components'
 import withThemeContext from 'helpers/withThemeContext'
@@ -33,6 +33,10 @@ const StyledText = styled(Text)`
   overflow-wrap: break-word;
 `
 
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
+  height: 0.4em
+`
+
 function MetadataButton({
   disabled,
   goldStandard,
@@ -52,7 +56,18 @@ function MetadataButton({
       <Button
         a11yTitle="Open Metadata Information"
         disabled={disabled}
-        icon={<FontAwesomeIcon icon={faInfoCircle} />}
+        icon={
+          <Box
+            align='center'
+            border={{ color: 'black' }}
+            height='0.85em'
+            width='0.85em'
+            justify='center'
+            round
+          >
+            <StyledFontAwesomeIcon icon={faInfo}/>
+          </Box>
+        }
         onClick={toggleDrop}
         plain
         ref={targetEl}

--- a/src/components/EditorHeader/components/MoreButton/MoreButton.js
+++ b/src/components/EditorHeader/components/MoreButton/MoreButton.js
@@ -13,7 +13,7 @@ export default function MoreButton({
   toggleDownload
 }) {
   const store = React.useContext(AppContext)
-  const Icon = isOpen ? FormDown : FormUp
+  const Icon = isOpen ? FormUp : FormDown
   const onEditSettings = () => {
     setOpen(false)
     store.aggregations.toggleModal()

--- a/src/components/EditorHeader/components/MoreButton/MoreButton.spec.js
+++ b/src/components/EditorHeader/components/MoreButton/MoreButton.spec.js
@@ -56,6 +56,6 @@ describe('Component > UndoButton', function () {
   it('should set the icon to FormDown when open', function() {
     wrapper = shallow(<MoreButton isOpen={true} />)
     const html = wrapper.html()
-    expect(html).toContain('FormDown')
+    expect(html).toContain('FormUp')
   })
 })

--- a/src/components/EditorHeader/components/Title/Title.js
+++ b/src/components/EditorHeader/components/Title/Title.js
@@ -87,5 +87,5 @@ Title.defaultProps = {
   onEditer: false
 }
 
-export { CapitalText, Title }
+export { CapitalText, StyledHeading, Title }
 export default withRouter(observer(Title))

--- a/src/components/EditorHeader/components/Title/Title.js
+++ b/src/components/EditorHeader/components/Title/Title.js
@@ -16,6 +16,10 @@ const CapitalText = styled(Text)`
   text-transform: uppercase;
 `
 
+const StyledHeading = styled(Heading)`
+  font-weight: 300;
+`
+
 function Title({ history, match, onEditor }) {
   const routeTo = (path) => {
     const matchProfile = matchPath(history.location.pathname, { path });
@@ -68,7 +72,7 @@ function Title({ history, match, onEditor }) {
         )})}
       </Box>
       <Box align='baseline' direction='row' gap='0.5em'>
-        <Heading margin='0em'>{header.title}</Heading>
+        <StyledHeading margin='0em'>{header.title}</StyledHeading>
         {subjectCount.length > 0 && <CapitalText color='#5C5C5C'>{subjectCount}</CapitalText>}
       </Box>
     </Box>

--- a/src/components/EditorHeader/components/Title/Title.spec.js
+++ b/src/components/EditorHeader/components/Title/Title.spec.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { Button, Heading } from 'grommet'
-import { CapitalText, Title } from './Title'
+import { Button } from 'grommet'
+import { CapitalText, StyledHeading, Title } from './Title'
 
 let wrapper
 const editContext = {
@@ -53,8 +53,8 @@ describe('Component > Title', function () {
 
     it('Should display only the group subheader', function () {
       expect(wrapper.find(Button).length).toBe(1)
-      expect(wrapper.find(Heading).length).toBe(1)
-      expect(wrapper.find(Heading).props().children).toBe(editContext.transcriptions.title)
+      expect(wrapper.find(StyledHeading).length).toBe(1)
+      expect(wrapper.find(StyledHeading).props().children).toBe(editContext.transcriptions.title)
     })
   })
 

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -22,7 +22,7 @@ function FilmstripViewer ({ disabled, selectImage, subjectIndex, images, isOpen,
     <RelativeBox background='#FFFFFF' pad='xsmall' round={{ size: 'xsmall', corner: 'top' }}>
       {disabled && <Overlay />}
       <Box direction='row' justify='between'>
-        <Text>All pages</Text>
+        <Text size='1em'>All Pages</Text>
         {!isOpen && (
           <StepNavigation
             activeStep={subjectIndex}

--- a/src/components/SubjectViewer/components/ImageTools/ImageTools.js
+++ b/src/components/SubjectViewer/components/ImageTools/ImageTools.js
@@ -9,17 +9,17 @@ function ImageTools() {
   const borderStyle = { side: 'right', color: '#979797' }
   return (
     <Box
-      background='#A6A7A9'
+      background={{ color: 'white', opacity: '50%' }}
       direction='row'
       elevation='large'
       margin='small'
       round='xxsmall'
     >
       <Box border={borderStyle}>
-        <ZoomInButtonContainer />
+        <ZoomOutButtonContainer />
       </Box>
       <Box border={borderStyle}>
-        <ZoomOutButtonContainer />
+        <ZoomInButtonContainer />
       </Box>
       <Box border={borderStyle}>
         <RotateButtonContainer />

--- a/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeader.js
+++ b/src/components/SubjectViewer/components/SubjectViewerHeader/SubjectViewerHeader.js
@@ -8,7 +8,7 @@ export default function SubjectViewerHeader({ linesVisible, toggleLineVisibility
   return (
     <Box background={{ color: 'white' }} round={{ size: 'xsmall', corner: 'top' }} pad='xsmall'>
       <Box align='center' direction='row' justify='between'>
-        <Text>Original Subject</Text>
+        <Text size='1em'>Original Subject</Text>
         <Box direction='row' gap='small'>
           <Button
             label={<Text>{text}</Text>}

--- a/src/theme.js
+++ b/src/theme.js
@@ -32,10 +32,10 @@ const theme = {
       knob: {
         extend: ({ checked }) => `
         background-color: #FFFFFF;
-        border: 2px solid #5C5C5C;
+        border: 1px solid #5C5C5C;
         height: 1em;
         width: 1em;
-        ${checked ? `margin: 0.15em 0;` : `margin: 0.15em`}
+        ${checked ? `margin: 0.2em 0;` : `margin: 0.2em`}
         `
       }
     }

--- a/src/theme.js
+++ b/src/theme.js
@@ -36,6 +36,21 @@ const theme = {
         height: 1em;
         width: 1em;
         ${checked ? `margin: 0.2em 0;` : `margin: 0.2em`}
+        ${checked ? `
+          &::before {
+            content: "\u2713";
+            left: 1px;
+            position: absolute;
+            top: -3px;
+          }
+        ` : `
+          &::before {
+            content: "\u0078";
+            left: 3px;
+            position: absolute;
+            top: -5px;
+          }
+        `}
         `
       }
     }


### PR DESCRIPTION
This PR takes care of remaining items in the "Main Interface" and "Original Subject" section of #110. **Note:** I'm not too worried about the test coverage decreasing here as it's minimal and could also be contributed to removing lines from some refactoring in this PR.

- Adjusted to image tools background and order (Fig. 2)
- Added an "X" and check mark on the mark as approved button
- Switched the up and down arrows for drop buttons
- Changed the font size for header buttons

Fig 1:
<img width="846" alt="Screen Shot 2020-03-23 at 8 52 04 AM" src="https://user-images.githubusercontent.com/14099077/77323792-ccf1dc00-6ce3-11ea-829c-ce3b034a8aaf.png">

Fig 2:
<img width="217" alt="Screen Shot 2020-03-23 at 8 53 21 AM" src="https://user-images.githubusercontent.com/14099077/77323796-cebb9f80-6ce3-11ea-9eb6-94f81639680d.png">
