### PR TITLE
Indexes Design Notes

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -1207,7 +1207,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         >
                           <svg
                             aria-label="FormDown"
-                            className="StyledIcon-ofa7kd-0 bgjyaD"
+                            className="StyledIcon-ofa7kd-0 bKsZCm"
                             viewBox="0 0 24 24"
                           >
                             <polyline
@@ -1297,7 +1297,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                   >
                     <label
                       checked={false}
-                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
+                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gHIYHd"
                       disabled={false}
                       htmlFor="unseen"
                       onClick={[Function]}
@@ -1309,7 +1309,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
+                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dijSVl"
                           disabled={false}
                           id="unseen"
                           name="unseen"
@@ -1320,7 +1320,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         />
                         <div
                           checked={false}
-                          className="StyledBox-sc-13pk1d4-0 SUcEn StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
+                          className="StyledBox-sc-13pk1d4-0 eoaItH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
                           disabled={false}
                         />
                       </div>
@@ -1344,7 +1344,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                   >
                     <label
                       checked={false}
-                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
+                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gHIYHd"
                       disabled={false}
                       htmlFor="in_progress"
                       onClick={[Function]}
@@ -1356,7 +1356,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
+                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dijSVl"
                           disabled={false}
                           id="in_progress"
                           name="in_progress"
@@ -1367,7 +1367,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         />
                         <div
                           checked={false}
-                          className="StyledBox-sc-13pk1d4-0 SUcEn StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
+                          className="StyledBox-sc-13pk1d4-0 eoaItH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
                           disabled={false}
                         />
                       </div>
@@ -1391,7 +1391,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                   >
                     <label
                       checked={false}
-                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
+                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gHIYHd"
                       disabled={false}
                       htmlFor="ready"
                       onClick={[Function]}
@@ -1403,7 +1403,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
+                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dijSVl"
                           disabled={false}
                           id="ready"
                           name="ready"
@@ -1414,7 +1414,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         />
                         <div
                           checked={false}
-                          className="StyledBox-sc-13pk1d4-0 SUcEn StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
+                          className="StyledBox-sc-13pk1d4-0 eoaItH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
                           disabled={false}
                         />
                       </div>
@@ -1438,7 +1438,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                   >
                     <label
                       checked={false}
-                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
+                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gHIYHd"
                       disabled={false}
                       htmlFor="approved"
                       onClick={[Function]}
@@ -1450,7 +1450,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
+                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dijSVl"
                           disabled={false}
                           id="approved"
                           name="approved"
@@ -1461,7 +1461,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         />
                         <div
                           checked={false}
-                          className="StyledBox-sc-13pk1d4-0 SUcEn StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
+                          className="StyledBox-sc-13pk1d4-0 eoaItH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
                           disabled={false}
                         />
                       </div>
@@ -1494,7 +1494,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                   >
                     <label
                       checked={false}
-                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 kWeChd"
+                      className="StyledCheckBox__StyledCheckBoxContainer-sc-1dbk5ju-1 gHIYHd"
                       disabled={false}
                       htmlFor="flagged"
                       onClick={[Function]}
@@ -1506,7 +1506,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                       >
                         <input
                           checked={false}
-                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dOuVEs"
+                          className="StyledCheckBox__StyledCheckBoxInput-sc-1dbk5ju-2 dijSVl"
                           disabled={false}
                           id="flagged"
                           name="flagged"
@@ -1517,7 +1517,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                         />
                         <div
                           checked={false}
-                          className="StyledBox-sc-13pk1d4-0 SUcEn StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
+                          className="StyledBox-sc-13pk1d4-0 eoaItH StyledCheckBox__StyledCheckBoxBox-sc-1dbk5ju-3 fxKnpz"
                           disabled={false}
                         />
                       </div>

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -100,5 +100,5 @@ Badge.propTypes = {
   src: PropTypes.string
 }
 
-export { DropLink }
+export { DropLink, StyledBox }
 export default Badge

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -26,10 +26,12 @@ const DropItem = styled(Button)`
 `
 
 const DropLink = styled(Link)`
-  background: ${props => props.disabled ? '#D8D8D8' : 'inherit'}
   pointer-events: ${props => props.disabled ? 'none' : 'all'}
   text-decoration: none;
+`
 
+const StyledBox = styled(Box)`
+  background: ${props => props.disabled ? '#D8D8D8' : 'inherit'}
   :hover {
     background: #D8D8D8;
   }
@@ -51,14 +53,20 @@ function Badge ({ disabled, isOpen, name, onAbout, role, setOpen, signOut, src }
         dropAlign={{ right: 'right', top: 'bottom' }}
         label={<Box><Icon/></Box>}
         dropContent={
-          <Box background='white' width='5em' pad={{ vertical: 'xxsmall' }}>
-            <DropLink disabled={onAbout} margin='1em' to='/about' tabIndex={onAbout ? -1 : undefined}>
-              <CapitalText color='#5C5C5C' margin='1em'>Help</CapitalText>
-            </DropLink>
-            <DropLink disabled={!onAbout} margin='1em' to='/projects' tabIndex={!onAbout ? -1 : undefined}>
-              <CapitalText color='#5C5C5C' margin='1em'>Viewer</CapitalText>
-            </DropLink>
-            <DropItem label={<CapitalText margin='1em'>Log out</CapitalText>} onClick={signOut} plain />
+          <Box background='white' height='7.5em' width='6em' pad={{ vertical: 'xxsmall' }}>
+            <StyledBox disabled={onAbout} justify='center' height='2.5em'>
+              <DropLink disabled={onAbout} to='/about' tabIndex={onAbout ? -1 : undefined}>
+                <CapitalText color='#5C5C5C' margin='1em'>Help</CapitalText>
+              </DropLink>
+            </StyledBox>
+            <StyledBox disabled={!onAbout} justify='center' height='2.5em'>
+              <DropLink disabled={!onAbout} to='/projects' tabIndex={!onAbout ? -1 : undefined}>
+                <CapitalText color='#5C5C5C' margin='1em'>Viewer</CapitalText>
+              </DropLink>
+            </StyledBox>
+            <StyledBox justify='center' height='2.5em'>
+              <DropItem label={<CapitalText margin='1em'>Log out</CapitalText>} onClick={signOut} plain />
+            </StyledBox>
           </Box>
         }
         onClose={() => setOpen(false)}

--- a/src/components/Badge/Badge.spec.js
+++ b/src/components/Badge/Badge.spec.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
 import { DropButton } from 'grommet'
-import Badge, { DropLink } from './Badge'
+import Badge, { DropLink, StyledBox } from './Badge'
 import { BrowserRouter as Router } from 'react-router-dom'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
@@ -37,7 +37,6 @@ describe('Component > Badge', function () {
           <DropLink />
         </Router>)
       const tree = renderer.create(wrapper).toJSON()
-      expect(tree).toHaveStyleRule('background', 'inherit')
       expect(tree).toHaveStyleRule('pointer-events', 'all')
     })
 
@@ -47,8 +46,21 @@ describe('Component > Badge', function () {
           <DropLink disabled />
         </Router>)
       const tree = renderer.create(wrapper).toJSON()
-      expect(tree).toHaveStyleRule('background', '#D8D8D8')
       expect(tree).toHaveStyleRule('pointer-events', 'none')
+    })
+  })
+
+  describe('StyledBox', function () {
+    it('should enable the component', function () {
+      wrapper = shallow(<StyledBox />)
+      const tree = renderer.create(wrapper).toJSON()
+      expect(tree).toHaveStyleRule('background', 'inherit')
+    })
+
+    it('should disable the component', function () {
+      wrapper = shallow(<StyledBox disabled />)
+      const tree = renderer.create(wrapper).toJSON()
+      expect(tree).toHaveStyleRule('background', '#D8D8D8')
     })
   })
 

--- a/src/components/SearchModal/components/SearchCheckBox.js
+++ b/src/components/SearchModal/components/SearchCheckBox.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { CheckBox, Text } from 'grommet'
 import PropTypes from 'prop-types'
+import withThemeContext from 'helpers/withThemeContext'
+import theme from './theme'
 
 function SearchCheckBox({ checked, disabled, label, onChange, title }) {
   return (
@@ -31,4 +33,5 @@ SearchCheckBox.propTypes = {
   title: PropTypes.string
 }
 
-export default SearchCheckBox
+export { SearchCheckBox }
+export default withThemeContext(SearchCheckBox, theme)

--- a/src/components/SearchModal/components/SearchCheckBox.spec.js
+++ b/src/components/SearchModal/components/SearchCheckBox.spec.js
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import SearchCheckBox from './SearchCheckBox'
+import { SearchCheckBox } from './SearchCheckBox'
 
 let wrapper;
 

--- a/src/components/SearchModal/components/theme.js
+++ b/src/components/SearchModal/components/theme.js
@@ -1,0 +1,12 @@
+const theme = {
+  checkBox: {
+    hover: {
+      border: {
+        color: 'inherit'
+      }
+    },
+    size: '0.7em'
+  }
+}
+
+export default theme

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -14,10 +14,11 @@ function SubjectsPageContainer ({ history, match }) {
   React.useEffect(() => {
     const setResources = async () => {
       await store.getResources(match.params)
-      await store.transcriptions.fetchTranscriptions()
-      store.search.reset()
+      await store.transcriptions.fetchTranscriptions(store.transcriptions.page, false)
     }
-    setResources()
+    if (!(store.transcriptions.current && store.transcriptions.current.id)) {
+      setResources()
+    }
     return () => store.modal.toggleModal('')
   }, [match, store])
 

--- a/src/screens/WorkflowsIndex/WorkflowsPageContainer.js
+++ b/src/screens/WorkflowsIndex/WorkflowsPageContainer.js
@@ -20,6 +20,7 @@ function WorkflowsPageContainer({ history, match }) {
 
   const onSelection = workflow => {
     const nextPath = generatePath(GROUPS_PATH, { workflow: workflow.id, ...match.params})
+    store.search.reset()
     history.push(nextPath)
   }
   const workflows = Array.from(store.workflows.all.values())

--- a/src/screens/WorkflowsIndex/WorkflowsPageContainer.spec.js
+++ b/src/screens/WorkflowsIndex/WorkflowsPageContainer.spec.js
@@ -10,9 +10,13 @@ let wrapper
 const fetchWorkflowsSpy = jest.fn()
 const pushSpy = jest.fn()
 const getResourcesSpy = jest.fn()
+const resetSpy = jest.fn()
 const selectWorkflowSpy = jest.fn()
 const contextValues = {
   getResources: getResourcesSpy,
+  search: {
+    reset: resetSpy
+  },
   workflows: {
     all: [],
     asyncState: ASYNC_STATES.IDLE,
@@ -48,6 +52,7 @@ describe('Component > WorkflowsPageContainer', function () {
       const workflow = { id: 1 }
       const table = wrapper.find(ResourcesTable).first()
       table.props().onSelection(workflow)
+      expect(resetSpy).toHaveBeenCalled()
       expect(pushSpy).toHaveBeenCalled()
     })
 

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -121,8 +121,8 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     self.setParsedExtracts(arrangedExtractsByUser)
   })
 
-  const fetchTranscriptions = function * fetchTranscriptions(page = 0) {
-    self.reset()
+  const fetchTranscriptions = function * fetchTranscriptions(page = 0, shouldReset = true) {
+    if (shouldReset) self.reset()
     self.page = page
     const groupName = getRoot(self).groups.title
     const workflow = getRoot(self).workflows.current.id

--- a/src/theme.js
+++ b/src/theme.js
@@ -64,6 +64,11 @@ const theme = {
       background: 'rgba(225, 225, 225, 0.75)'
     }
   },
+  select: {
+    icons: {
+      color: 'black'
+    }
+  },
   table: {
     extend: props => `
       tr:nth-child(even) {


### PR DESCRIPTION
Covers all items in the Indexes section of #110 ("General" and "Search/Filter"). **Note:** I'm not too worried about the test coverage decreasing here as it's minimal and could also be contributed to removing lines from some refactoring in this PR.

Closes #110 

- Adjust size of checkboxes
- Adjust the padding around username badge
- Persist search filters when going back to the transcriptions page. Ex: Let's say you are filtering or searching subjects on the subjects index page and then you select a subject/transcription to view in the editor. Once you're on the editor page, you should be able to press the group name (above the subject ID on the top left) to go back to the subjects index page. You should then see all the previous search filters still in place.

Badge
<img width="212" alt="Screen Shot 2020-03-23 at 8 56 49 AM" src="https://user-images.githubusercontent.com/14099077/77324164-5e614e00-6ce4-11ea-9c8d-9fbd53d47cd8.png">

Breadcrumbs
<img width="476" alt="Screen Shot 2020-03-23 at 8 56 58 AM" src="https://user-images.githubusercontent.com/14099077/77324171-602b1180-6ce4-11ea-8aa7-336fd93a3361.png">

Search Filters
<img width="435" alt="Screen Shot 2020-03-23 at 8 57 09 AM" src="https://user-images.githubusercontent.com/14099077/77324176-628d6b80-6ce4-11ea-928b-e7ac063948c2.png">
