### PR TITLE
Reparse Extracts after Rearranging

### DIFF
--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -254,6 +254,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   function setTextObject(text) {
     self.current.text.set(`frame${self.index}`, text)
+    self.setParsedExtracts()
     self.saveTranscription()
   }
 


### PR DESCRIPTION
Closes #120 

This PR takes care of an issue that emerged from a PR review. Transcription rows were being arranged without reparsing the order of the extracts, which accounts for displaying a user's transcription when the modal is open. 