### PR TITLE
Transcription Locking and Unlocking

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -1436,9 +1436,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         This subject cannot be accessed because 
-        <b>
-          Erin Green
-        </b>
+        <b />
          is currently accessing it.
       </span>
       <div

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -1436,7 +1436,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         This subject cannot be accessed because 
-        <b />
+        <strong />
          is currently accessing it.
       </span>
       <div

--- a/src/components/Badge/BadgeContainer.js
+++ b/src/components/Badge/BadgeContainer.js
@@ -9,7 +9,6 @@ function BadgeContainer ({ onAbout }) {
   const user = store.auth.user
 
   const disabled = store.aggregations.showModal || store.transcriptions.isActive
-  const name = user && user.display_name
   const signOut = store.auth.logout
   const src = user && user.avatar_src
 
@@ -17,7 +16,7 @@ function BadgeContainer ({ onAbout }) {
     <Badge
       disabled={disabled}
       isOpen={isOpen}
-      name={name}
+      name={store.auth.userName}
       onAbout={onAbout}
       role={store.projects.role}
       setOpen={setOpen}

--- a/src/components/Badge/BadgeContainer.spec.js
+++ b/src/components/Badge/BadgeContainer.spec.js
@@ -12,10 +12,8 @@ const contextValues = {
   },
   auth: {
     logout: () => {},
-    user: {
-      avatar_src: 'source.jpg',
-      display_name: 'Test_User',
-    }
+    user: { avatar_src: 'source.jpg' },
+    userName: 'Test_User'
   },
   projects: {
     role: 'Researcher'
@@ -56,7 +54,7 @@ describe('Component > BadgeContainer', function () {
 
   it('should pass the src prop', function () {
     const name = badgeComponent.props().name
-    expect(name).toBe(contextValues.auth.user.display_name)
+    expect(name).toBe(contextValues.auth.userName)
     expect(typeof name).toBe('string')
   })
 })

--- a/src/components/Modals/SubjectLockedModal/SubjectLockedModal.js
+++ b/src/components/Modals/SubjectLockedModal/SubjectLockedModal.js
@@ -7,7 +7,7 @@ const StyledText = styled(Text)`
   line-height: 1.75em;
 `
 
-export default function SubjectLockedModal({ onBack }) {
+export default function SubjectLockedModal({ lockedBy, onBack }) {
   return (
     <Box
       background='white'
@@ -19,7 +19,7 @@ export default function SubjectLockedModal({ onBack }) {
     >
       <Text size='large'>Subject locked</Text>
       <StyledText>
-        This subject cannot be accessed because <b>Erin Green</b> is currently accessing it.
+        This subject cannot be accessed because <b>{lockedBy}</b> is currently accessing it.
       </StyledText>
       <StyledText>For access, ask them to close their version.</StyledText>
       <Button

--- a/src/components/Modals/SubjectLockedModal/SubjectLockedModal.js
+++ b/src/components/Modals/SubjectLockedModal/SubjectLockedModal.js
@@ -19,7 +19,7 @@ export default function SubjectLockedModal({ lockedBy, onBack }) {
     >
       <Text size='large'>Subject locked</Text>
       <StyledText>
-        This subject cannot be accessed because <b>{lockedBy}</b> is currently accessing it.
+        This subject cannot be accessed because <strong>{lockedBy}</strong> is currently accessing it.
       </StyledText>
       <StyledText>For access, ask them to close their version.</StyledText>
       <Button

--- a/src/components/Modals/SubjectLockedModal/SubjectLockedModalContainer.js
+++ b/src/components/Modals/SubjectLockedModal/SubjectLockedModalContainer.js
@@ -2,10 +2,12 @@ import React from 'react'
 import AppContext from 'store'
 import { generatePath, matchPath, withRouter } from 'react-router-dom'
 import { SUBJECTS_PATH } from 'paths'
+import { observer } from 'mobx-react'
 import SubjectLockedModal from './SubjectLockedModal'
 
 function SubjectLockedModalContainer(props) {
   const store = React.useContext(AppContext)
+  const lockedBy = store.transcriptions.current && store.transcriptions.current.locked_by
   const onBack = () => {
     store.modal.toggleModal('')
     const matchProfile = matchPath(props.history.location.pathname, { path: SUBJECTS_PATH });
@@ -15,8 +17,8 @@ function SubjectLockedModalContainer(props) {
     }
   }
 
-  return <SubjectLockedModal onBack={onBack} />
+  return <SubjectLockedModal lockedBy={lockedBy} onBack={onBack} />
 }
 
-export default withRouter(SubjectLockedModalContainer)
 export { SubjectLockedModalContainer }
+export default withRouter(observer(SubjectLockedModalContainer))

--- a/src/components/Modals/SubjectLockedModal/SubjectLockedModalContainer.spec.js
+++ b/src/components/Modals/SubjectLockedModal/SubjectLockedModalContainer.spec.js
@@ -14,6 +14,9 @@ let history = {
 const contextValues = {
   modal: {
     toggleModal: toggleModalSpy,
+  },
+  transcriptions: {
+    current: { locked_by: 'A_USER' }
   }
 }
 

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -33,6 +33,11 @@ function Editor ({ match }) {
     setResources()
     store.transcriptions.setActiveTranscription()
     undoManager.clear()
+
+    // window.addEventListener('beforeunload', function() {
+    //   store.transcriptions.unlockTranscription()
+    // });
+    return () => store.transcriptions.unlockTranscription()
   }, [match, store])
 
   const disabled = store.aggregations.showModal || store.transcriptions.approved || store.transcriptions.isActive

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react'
 import { withRouter } from 'react-router-dom'
 import AppContext from 'store'
 import { undoManager } from 'store/AppStore'
+import MODALS from 'helpers/modals'
 import Resizer from './components/Resizer'
 import AggregationModal from '../../components/AggregationSettings/AggregationModal'
 import SubjectViewer from '../../components/SubjectViewer'
@@ -21,6 +22,14 @@ function findLocations(subject) {
   })
 }
 
+function shouldShowLockedModal(store) {
+  const { auth, transcriptions } = store
+  if (transcriptions.current) {
+    return auth.userName !== transcriptions.current.locked_by
+  }
+  return false
+}
+
 function Editor ({ match, testTime }) {
   const store = React.useContext(AppContext)
   const editorBox = React.useRef(null)
@@ -31,6 +40,9 @@ function Editor ({ match, testTime }) {
     const setResources = async () => {
       await store.subjects.fetchSubject(match.params.subject)
       await store.getResources(match.params)
+      if (shouldShowLockedModal(store)) {
+        store.modal.toggleModal(MODALS.LOCKED)
+      }
     }
     setResources()
     store.transcriptions.setActiveTranscription()

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -34,9 +34,9 @@ function Editor ({ match }) {
     store.transcriptions.setActiveTranscription()
     undoManager.clear()
 
-    // window.addEventListener('beforeunload', function() {
-    //   store.transcriptions.unlockTranscription()
-    // });
+    window.addEventListener('beforeunload', function() {
+      store.transcriptions.unlockTranscription()
+    });
     return () => store.transcriptions.unlockTranscription()
   }, [match, store])
 

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -22,14 +22,6 @@ function findLocations(subject) {
   })
 }
 
-function shouldShowLockedModal(store) {
-  const { auth, transcriptions } = store
-  if (transcriptions.current) {
-    return auth.userName !== transcriptions.current.locked_by
-  }
-  return false
-}
-
 function Editor ({ match, testTime }) {
   const store = React.useContext(AppContext)
   const editorBox = React.useRef(null)
@@ -40,7 +32,7 @@ function Editor ({ match, testTime }) {
     const setResources = async () => {
       await store.subjects.fetchSubject(match.params.subject)
       await store.getResources(match.params)
-      if (shouldShowLockedModal(store)) {
+      if (!store.transcriptions.lockedByCurrentUser) {
         store.modal.toggleModal(MODALS.LOCKED)
       }
     }
@@ -62,7 +54,9 @@ function Editor ({ match, testTime }) {
     window.addEventListener('visibilitychange', handleTimeCheck)
 
     return () => {
-      store.transcriptions.unlockTranscription()
+      if (store.transcriptions.lockedByCurrentUser) {
+        store.transcriptions.unlockTranscription()
+      }
       window.removeEventListener('beforeunload', store.transcriptions.unlockTranscription);
       window.removeEventListener('visibilitychange', handleTimeCheck)
     }

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -21,7 +21,7 @@ function findLocations(subject) {
   })
 }
 
-function Editor ({ match }) {
+function Editor ({ match, testTime }) {
   const store = React.useContext(AppContext)
   const editorBox = React.useRef(null)
 
@@ -37,7 +37,7 @@ function Editor ({ match }) {
     undoManager.clear()
 
     function handleTimeCheck() {
-      let recheckTime = new Date(accessTime).setHours(accessTime.getHours() + 3)
+      let recheckTime = testTime || new Date(accessTime).setHours(accessTime.getHours() + 3)
       const shouldRecheck = new Date() > recheckTime
       if (shouldRecheck) {
         accessTime = new Date()
@@ -54,7 +54,7 @@ function Editor ({ match }) {
       window.removeEventListener('beforeunload', store.transcriptions.unlockTranscription);
       window.removeEventListener('visibilitychange', handleTimeCheck)
     }
-  }, [match, store])
+  }, [testTime, match, store])
 
   const disabled = store.aggregations.showModal || store.transcriptions.approved || store.transcriptions.isActive
   const subject = store.subjects.current

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -36,11 +36,7 @@ function Editor ({ match }) {
     store.transcriptions.setActiveTranscription()
     undoManager.clear()
 
-    window.addEventListener('beforeunload', function() {
-      store.transcriptions.unlockTranscription()
-    });
-
-    window.addEventListener('visibilitychange', function() {
+    function handleTimeCheck() {
       let recheckTime = new Date(accessTime).setHours(accessTime.getHours() + 3)
       const shouldRecheck = new Date() > recheckTime
       if (shouldRecheck) {
@@ -48,13 +44,15 @@ function Editor ({ match }) {
         recheckTime = new Date(accessTime).setHours(accessTime.getHours() + 3)
         store.transcriptions.checkIfLocked()
       }
-    })
+    }
+
+    window.addEventListener('beforeunload', store.transcriptions.unlockTranscription)
+    window.addEventListener('visibilitychange', handleTimeCheck)
+
     return () => {
       store.transcriptions.unlockTranscription()
-
-      window.removeEventListener('beforeunload', function() {
-        store.transcriptions.unlockTranscription()
-      });
+      window.removeEventListener('beforeunload', store.transcriptions.unlockTranscription);
+      window.removeEventListener('visibilitychange', handleTimeCheck)
     }
   }, [match, store])
 

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -15,9 +15,7 @@ function SubjectsPageContainer ({ history, match }) {
       await store.getResources(match.params)
       await store.transcriptions.fetchTranscriptions(store.transcriptions.page, false)
     }
-    if (!(store.transcriptions.current && store.transcriptions.current.id)) {
-      setResources()
-    }
+    setResources()
   }, [match, store])
 
   const onSelection = (transcription) => {

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -22,11 +22,10 @@ function SubjectsPageContainer ({ history, match }) {
     return () => store.modal.toggleModal('')
   }, [match, store])
 
-  const onSelection = (subject) => {
-    if (subject.locked) {
-      store.modal.toggleModal(MODALS.LOCKED)
-    }
-    const nextPath = generatePath(EDIT_PATH, { subject: subject.id, ...match.params})
+  const onSelection = (transcription) => {
+    const isLocked = transcription.locked_by && transcription.locked_by !== store.auth.userName
+    if (isLocked) store.modal.toggleModal(MODALS.LOCKED)
+    const nextPath = generatePath(EDIT_PATH, { subject: transcription.id, ...match.params})
     history.push(nextPath)
   }
 

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -4,7 +4,6 @@ import AppContext from 'store'
 import { generatePath, withRouter } from 'react-router-dom'
 import { observer } from 'mobx-react'
 import { EDIT_PATH } from 'paths'
-import MODALS from 'helpers/modals'
 import ResourcesTable from '../../components/ResourcesTable'
 import { columns } from './table'
 
@@ -19,12 +18,9 @@ function SubjectsPageContainer ({ history, match }) {
     if (!(store.transcriptions.current && store.transcriptions.current.id)) {
       setResources()
     }
-    return () => store.modal.toggleModal('')
   }, [match, store])
 
   const onSelection = (transcription) => {
-    const isLocked = transcription.locked_by && transcription.locked_by !== store.auth.userName
-    if (isLocked) store.modal.toggleModal(MODALS.LOCKED)
     const nextPath = generatePath(EDIT_PATH, { subject: transcription.id, ...match.params})
     history.push(nextPath)
   }

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
@@ -71,14 +71,6 @@ describe('Component > SubjectsPageContainer', function () {
       expect(fetchTranscriptionsSpy).toHaveBeenCalled()
     })
 
-    it('should toggleModal when subject locked', function() {
-      const subject = { id: 1, locked_by: 'ANOTHER_USER' }
-      const table = wrapper.find(ResourcesTable).first()
-      table.props().onSelection(subject)
-      expect(toggleModalSpy).toHaveBeenCalledWith(MODALS.LOCKED)
-      expect(pushSpy).toHaveBeenCalled()
-    })
-
     it('should not toggleModal when subject unlocked', function() {
       const subject = { id: 1, locked: false }
       const table = wrapper.find(ResourcesTable).first()

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
@@ -14,6 +14,7 @@ const pushSpy = jest.fn()
 const resetSpy = jest.fn()
 const toggleModalSpy = jest.fn()
 const contextValues = {
+  auth: { userName: 'A_USER' },
   getResources: getResourcesSpy,
   modal: {
     toggleModal: toggleModalSpy
@@ -71,7 +72,7 @@ describe('Component > SubjectsPageContainer', function () {
     })
 
     it('should toggleModal when subject locked', function() {
-      const subject = { id: 1, locked: true }
+      const subject = { id: 1, locked_by: 'ANOTHER_USER' }
       const table = wrapper.find(ResourcesTable).first()
       table.props().onSelection(subject)
       expect(toggleModalSpy).toHaveBeenCalledWith(MODALS.LOCKED)

--- a/src/screens/SubjectsIndex/table.js
+++ b/src/screens/SubjectsIndex/table.js
@@ -30,7 +30,7 @@ const columns = [
     ),
     render: datum => {
       const color = datum.locked ? 'red' : 'inherit'
-      return <Text color={color}>{datum.locked ? 'LOCKED' : writeDate(datum.updated_at)}</Text>
+      return <Text color={color}>{datum.locked_by ? 'LOCKED' : writeDate(datum.updated_at)}</Text>
     }
   },
   {

--- a/src/screens/SubjectsIndex/table.js
+++ b/src/screens/SubjectsIndex/table.js
@@ -29,7 +29,8 @@ const columns = [
       <HeaderButton property='updated_at' title='LAST EDIT' />
     ),
     render: datum => {
-      const color = datum.locked ? 'red' : 'inherit'
+      console.log(datum);
+      const color = datum.locked_by ? 'red' : 'inherit'
       return <Text color={color}>{datum.locked_by ? 'LOCKED' : writeDate(datum.updated_at)}</Text>
     }
   },

--- a/src/screens/SubjectsIndex/table.js
+++ b/src/screens/SubjectsIndex/table.js
@@ -29,7 +29,6 @@ const columns = [
       <HeaderButton property='updated_at' title='LAST EDIT' />
     ),
     render: datum => {
-      console.log(datum);
       const color = datum.locked_by ? 'red' : 'inherit'
       return <Text color={color}>{datum.locked_by ? 'LOCKED' : writeDate(datum.updated_at)}</Text>
     }

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -44,6 +44,10 @@ const AuthStore = types.model('AuthStore', {
     self.user = null
     history.push('/')
   })
+})).views(self => ({
+  get userName () {
+    return self.user && self.user.display_name
+  }
 }))
 
 export { AuthStore }

--- a/src/store/AuthStore.spec.js
+++ b/src/store/AuthStore.spec.js
@@ -2,7 +2,7 @@ import auth from 'panoptes-client/lib/auth'
 import { AppStore } from './AppStore'
 import history from '../history'
 
-const user = { id: '1' }
+const user = { id: '1', display_name: 'A_USER' }
 
 let authStore
 const setBearerTokenSpy = jest.fn()
@@ -34,6 +34,7 @@ describe('AuthStore', function () {
       await authStore.login('login', 'password', setSubmittingSpy)
       expect(setSubmittingSpy).toHaveBeenCalledWith(false)
       expect(authStore.user).toBe(user)
+      expect(authStore.userName).toBe(user.display_name)
     })
   })
 

--- a/src/store/ClientStore.spec.js
+++ b/src/store/ClientStore.spec.js
@@ -25,7 +25,6 @@ describe('ClientStore', function () {
       }
     })
     clientStore = rootStore.client
-    console.log('root', rootStore.workflows.current);
   })
 
   afterEach(() => jest.clearAllMocks());

--- a/src/store/Reduction.js
+++ b/src/store/Reduction.js
@@ -23,7 +23,7 @@ const Reduction = types.model('Reduction', {
 .actions(self => ({
   setConsensusText: (text, isOriginalOption = false, originalTranscriber = '') => {
     self.original_transcriber = originalTranscriber
-    self.line_editor = isOriginalOption ? '' : getRoot(self).auth.user.display_name
+    self.line_editor = isOriginalOption ? '' : getRoot(self).auth.userName
     self.edited_consensus_text = isOriginalOption ? '' : text
 
     const transcription = getRoot(self).transcriptions

--- a/src/store/Reduction.spec.js
+++ b/src/store/Reduction.spec.js
@@ -7,9 +7,7 @@ const saveTranscriptionsSpy = jest.fn()
 
 const consensusText = 'Consensus Text'
 const contextValues = {
-  auth: {
-    user: { display_name: 'User' }
-  },
+  auth: { userName: 'User' },
   transcriptions: {
     checkForFlagUpdate: checkForFlagUpdateSpy,
     saveTranscription: saveTranscriptionsSpy

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -105,7 +105,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const text = (transcription.attributes && transcription.attributes.text) || {}
     const containsFrameKey = (val, key) => key.indexOf('frame') >= 0
     const textObject = Ramda.pickBy(containsFrameKey, text)
-    console.log(transcription);
     return Transcription.create({
       id: transcription.id,
       flagged: transcription.attributes.flagged,

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -378,7 +378,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   const unlockTranscription = flow(function * unlockTranscription() {
     const client = getRoot(self).client.tove
-    yield client.patch(`/transcriptions/${self.current.id}/unlock`, { headers: { 'If-Unmodified-Since': self.current.lastModified } })
+    yield client.patch(`/transcriptions/${self.current.id}/unlock`, { headers: { 'If-Unmodified-Since': self.current.last_modified } })
   })
 
   function updateApproval(isChecked) {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -404,7 +404,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     createTranscription: (transcription, lastModified) => undoManager.withoutUndo(() => createTranscription(transcription, lastModified)),
     deleteCurrentLine,
     fetchExtracts,
-    fetchTranscriptions: (page) => undoManager.withoutUndo(() => flow(fetchTranscriptions))(page),
+    fetchTranscriptions: (page, shouldReset) => undoManager.withoutUndo(() => flow(fetchTranscriptions))(page, shouldReset),
     getLastModified,
     getTranscriberInfo,
     patchTranscription,

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -439,6 +439,11 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     return count;
   },
 
+  get lockedByCurrentUser () {
+    const user = getRoot(self).auth.userName
+    return user === self.current.locked_by
+  },
+
   get isActive () {
     return self.activeTranscriptionIndex !== undefined
   },

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -377,7 +377,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   const unlockTranscription = flow(function * unlockTranscription() {
-    console.log('unlocking');
     const client = getRoot(self).client.tove
     yield client.patch(`/transcriptions/${self.current.id}/unlock`, { headers: { 'If-Unmodified-Since': self.current.lastModified } })
   })

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -105,12 +105,14 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const text = (transcription.attributes && transcription.attributes.text) || {}
     const containsFrameKey = (val, key) => key.indexOf('frame') >= 0
     const textObject = Ramda.pickBy(containsFrameKey, text)
+    console.log(transcription);
     return Transcription.create({
       id: transcription.id,
       flagged: transcription.attributes.flagged,
       group_id: transcription.attributes.group_id,
       last_modified,
       internal_id: transcription.attributes.internal_id || '',
+      locked_by: transcription.attributes.locked_by,
       low_consensus_lines: transcription.attributes.low_consensus_lines || 0,
       pages: transcription.attributes.total_pages || 0,
       parameters: transcription.attributes.parameters,

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -216,7 +216,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const client = getRoot(self).client.tove
     let lastModified
     try {
-      yield client.patch(`/transcriptions/${self.current.id}`, { body: query, headers: { 'If-Unmodified-Since': self.current.lastModified } }).then(response => {
+      yield client.patch(`/transcriptions/${self.current.id}`, { body: query, headers: { 'If-Unmodified-Since': self.current.last_modified } }).then(response => {
         if (response.ok) {
           lastModified = getLastModified(response)
           return response
@@ -235,7 +235,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
       })
     }
     undoManager.withoutUndo(() => {
-      if (lastModified) self.current.lastModified = lastModified
+      if (lastModified) self.current.last_modified = lastModified
     })
   })
 

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -25,7 +25,8 @@ const getToveResponse = () => Promise.resolve(
         meta: {
           pagination: { last: 1 }
         }
-      })
+      }),
+    headers
   }
 )
 
@@ -286,6 +287,14 @@ describe('TranscriptionsStore', function () {
       it('should show when the transcription is locked', async function () {
         await transcriptionsStore.checkIfLocked()
         expect(toggleModalSpy).toHaveBeenCalled()
+      })
+
+      it('should unlock a transcription', async function () {
+        await transcriptionsStore.unlockTranscription()
+        expect(patchToveSpy).toHaveBeenCalledWith(
+          '/transcriptions/1/unlock',
+          {"headers": {"If-Unmodified-Since": "Mon, June 31, 2020"}}
+        )
       })
 
       describe('when deleting a line', function () {

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -297,6 +297,10 @@ describe('TranscriptionsStore', function () {
         )
       })
 
+      it('should return if the transcription is lockedByCurrentUser', function () {
+        expect(transcriptionsStore.lockedByCurrentUser).toBe(false)
+      })
+
       describe('when deleting a line', function () {
         it('should not proceed without an active transcription', function () {
           const current = transcriptionsStore.current.text.get('frame0')

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -241,7 +241,7 @@ describe('TranscriptionsStore', function () {
       it('should save a transcription', async function () {
         await transcriptionsStore.saveTranscription()
         expect(patchToveSpy).toHaveBeenCalled()
-        expect(transcriptionsStore.current.lastModified).toBe('Mon, June 31, 2020')
+        expect(transcriptionsStore.current.last_modified).toBe('Mon, June 31, 2020')
       })
 
       it('should update the flagged attribute', function () {


### PR DESCRIPTION
Closes #26 

Refer to [this doc](https://docs.google.com/document/d/1aBMwZM6X0wf-K0fkE0JPX9h_DHjj_hOBDCJzhJLx3ig/edit) for a bit more backend and frontend info. 

**Use case:**
For the text editor app, we don't want two people to be editing a transcription at the same time. Because of that, transcriptions have a `locked_by` attribute that is set to the person who is currently accessing a transcription. If you try to update a transcription that is `locked_by` another user, the `PATCH` (that occurs when attempting to update) will error, so that is a situation we want to avoid. **Important:** A user can lock a subject for three hours.

Most importantly, after a user finishes editing a transcription, that user should unlock a transcription by hitting an endpoint `/transcriptions/:id/unlock`, and **this is what we attempt to do via this PR**.

**How to Solve:**
Let's think of all the different ways a user might navigate away from a transcription.
- **Closing the Window or Browser:** This should be covered via the `beforeunload` event listener in this PR.  
- **Navigating Back:** This should be handled when the `Editor` component unmounts via the return statement of the Editor's `useEffect` hook in this PR.  
- **Inactivity:** This is the trickiest part. Let's say a user has their window open for over three hours or closes their laptop overnight and expects to open up and keep transcribing. However, upon resuming the work, that transcription has been locked by another user. We want to elegantly message this to the user.

  Because of this, I use the [Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) to check whenever a page changes visibility (triggered by tabbing into or opening/closing a laptop lid). Whenever this happen, we check if three hours (unlocking duration) have passed since the transcription was last accessed. If it has been more than three hours, we GET the transcription again to check if it is still free or has been `locked_by` another user. If the transcription is available, we refresh the access time and begin working for another three hours since it has presumably been re-locked.