### PR TITLE
Disable Line Clicking if Transcription Approved

### DIFF
--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.js
@@ -5,6 +5,7 @@ import SVGLines from './SVGLines'
 export default function AnnotationsPane({
   activeTranscriptionIndex,
   extractLines,
+  isApproved,
   linesVisible,
   onLineClick,
   reductionLines,
@@ -30,6 +31,7 @@ export default function AnnotationsPane({
         <SVGLines
           activeTranscriptionIndex={activeTranscriptionIndex}
           key={`SVG_LINE_${i}`}
+          isApproved={isApproved}
           lines={lines}
           onLineClick={() => onLineClick(i)}
           reductionIndex={i}
@@ -42,6 +44,7 @@ export default function AnnotationsPane({
 AnnotationsPane.propTypes = {
   activeTranscriptionIndex: number,
   extractLines: array,
+  isApproved: bool,
   linesVisible: bool,
   onLineClick: func,
   reductionLines: array,
@@ -52,6 +55,7 @@ AnnotationsPane.propTypes = {
 AnnotationsPane.defaultProps = {
   activeTranscriptionIndex: null,
   extractLines: [],
+  isApproved: false,
   linesVisible: true,
   onLineClick: () => {},
   reductionLines: [],

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
@@ -21,11 +21,12 @@ function AnnotationsPaneContainer({ x, y }) {
     <AnnotationsPane
       x={x}
       y={y}
-      linesVisible={store.editor.linesVisible}
-      extractLines={store.transcriptions.parsedExtracts}
-      reductionLines={reductionLines}
-      onLineClick={onLineClick}
       activeTranscriptionIndex={store.transcriptions.activeTranscriptionIndex}
+      extractLines={store.transcriptions.parsedExtracts}
+      isApproved={store.transcriptions.approved}
+      linesVisible={store.editor.linesVisible}
+      onLineClick={onLineClick}
+      reductionLines={reductionLines}
     />
   )
 }

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.spec.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.spec.js
@@ -12,6 +12,7 @@ const contextValues = {
     linesVisible: true
   },
   transcriptions: {
+    approved: false,
     current: {
       text: new Map([
         [ 'frame0', [{

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
@@ -3,7 +3,7 @@ import { array, bool, func, number } from 'prop-types'
 import indexToColor from 'helpers/indexToColor'
 import styled from 'styled-components'
 
-const G = styled('g')`
+export const G = styled('g')`
   cursor: ${props => props.clickable && !props.isApproved ? 'pointer' : 'inherit'};
 `
 

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
@@ -4,10 +4,10 @@ import indexToColor from 'helpers/indexToColor'
 import styled from 'styled-components'
 
 const G = styled('g')`
-  cursor: ${props => props.clickable ? 'pointer' : 'inherit'};
+  cursor: ${props => props.clickable && !props.isApproved ? 'pointer' : 'inherit'};
 `
 
-export default function SVGLines({ activeTranscriptionIndex, lines, onLineClick, isExtract, reductionIndex }) {
+export default function SVGLines({ activeTranscriptionIndex, isApproved, lines, onLineClick, isExtract, reductionIndex }) {
   const circleWidth = isExtract ? 4 : 10
   const dashArray = isExtract ? '4' : '0'
   const strokeWidth = isExtract ? '0.5' : '3'
@@ -16,7 +16,9 @@ export default function SVGLines({ activeTranscriptionIndex, lines, onLineClick,
   if (Number.isInteger(activeTranscriptionIndex) && !isActive) return null
 
   return (
-    <G clickable={!isExtract} onClick={onLineClick}>
+    <G clickable={!isExtract} isApproved={isApproved} onClick={() => {
+      if (!isApproved) onLineClick()
+    }}>
       {lines.map((line, index) => {
         const color = isExtract && isActive ? indexToColor(index) : indexToColor(reductionIndex)
         const svgPoints = []
@@ -74,6 +76,7 @@ export default function SVGLines({ activeTranscriptionIndex, lines, onLineClick,
 }
 
 SVGLines.propTypes = {
+  isApproved: bool,
   isExtract: bool,
   lines: array,
   onLineClick: func,
@@ -81,6 +84,7 @@ SVGLines.propTypes = {
 }
 
 SVGLines.defaultProps = {
+  isApproved: false,
   isExtract: false,
   lines: [],
   onLineClick: () => {},

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.spec.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.spec.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
-import SVGLines from './SVGLines'
+import SVGLines, { G } from './SVGLines'
 
 let wrapper
 
@@ -60,6 +60,24 @@ describe('Component > SVGLines', function () {
           reductionIndex={1}
         />);
       expect(wrapper).toEqual({})
+    })
+  })
+
+  describe('onLineClick', function () {
+    const onLineClickSpy = jest.fn()
+
+    afterEach(() => jest.clearAllMocks());
+
+    it('should trigger by default', function () {
+      wrapper = shallow(<SVGLines onLineClick={onLineClickSpy} />)
+      wrapper.find(G).first().props().onClick()
+      expect(onLineClickSpy).toHaveBeenCalled()
+    })
+
+    it('should not trigger with approved transcription', function () {
+      wrapper = shallow(<SVGLines isApproved onLineClick={onLineClickSpy} />)
+      wrapper.find(G).first().props().onClick()
+      expect(onLineClickSpy).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Closes #133 

When a transcription is approved, and the UI is disabled, a user should not be able to click a reduction line to open the transcription pane.