### PR TITLE
Show Subject on Second Access

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -1696,6 +1696,9 @@ exports[`Storyshots SubjectViewer Default 1`] = `
             className="StyledBox-sc-13pk1d4-0 fWrrBh sc-hzDkRC sc-jhAzac fZhiDl"
           />
         </div>
+        <div
+          className="StyledBox-sc-13pk1d4-0 lfMSfr"
+        />
       </div>
     </div>
   </div>

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import { array, bool, func, number } from 'prop-types'
+import { observer } from 'mobx-react'
 import SVGLines from './SVGLines'
 
-export default function AnnotationsPane({
+function AnnotationsPane({
   activeTranscriptionIndex,
   extractLines,
   linesVisible,
@@ -58,3 +59,5 @@ AnnotationsPane.defaultProps = {
   x: 0,
   y: 0
 }
+
+export default observer(AnnotationsPane)

--- a/src/components/SubjectViewer/components/SVGView/SVGView.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGView.js
@@ -56,5 +56,4 @@ SVGView.defaultProps = {
   width: 0
 }
 
-export { G }
 export default SVGView

--- a/src/components/SubjectViewer/components/SVGView/SVGView.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGView.js
@@ -15,15 +15,16 @@ const G = styled.g`
   }
 `
 
-function SVGView ({ disabled, height, url, transform, width}) {
-  const svgEl = React.useRef(null)
-  const boundingBox = svgEl.current && svgEl.current.getBoundingClientRect()
+const SVGView = React.forwardRef(function ({ disabled, height, url, transform, width}, ref) {
+  const boundingBox = ref.current && ref.current.getBoundingClientRect()
   const viewerWidth = (boundingBox && boundingBox.width) || 0
   const viewerHeight = (boundingBox && boundingBox.height) || 0
   const viewBox = `${-viewerWidth/2} ${-viewerHeight/2} ${viewerWidth || 0} ${viewerHeight || 0}`
 
+  if (url.length === 0 || disabled) return null;
+
   return (
-    <SVG ref={svgEl} viewBox={viewBox}>
+    <SVG viewBox={viewBox}>
       <G disabled={disabled} transform={transform}>
         <image
           height={height}
@@ -37,7 +38,7 @@ function SVGView ({ disabled, height, url, transform, width}) {
       </G>
     </SVG>
   )
-}
+})
 
 SVGView.propTypes = {
   disabled: bool,

--- a/src/components/SubjectViewer/components/SVGView/SVGView.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGView.js
@@ -11,21 +11,21 @@ const SVG = styled.svg`
 
 const G = styled.g`
   :hover {
-    cursor: ${props => props.disabled ? 'default' : 'move'};
+    cursor: move;
   }
 `
 
 const SVGView = React.forwardRef(function ({ disabled, height, url, transform, width}, ref) {
+  if (url.length === 0 || disabled || !ref) return null;
+
   const boundingBox = ref.current && ref.current.getBoundingClientRect()
   const viewerWidth = (boundingBox && boundingBox.width) || 0
   const viewerHeight = (boundingBox && boundingBox.height) || 0
   const viewBox = `${-viewerWidth/2} ${-viewerHeight/2} ${viewerWidth || 0} ${viewerHeight || 0}`
 
-  if (url.length === 0 || disabled) return null;
-
   return (
     <SVG viewBox={viewBox}>
-      <G disabled={disabled} transform={transform}>
+      <G transform={transform}>
         <image
           height={height}
           width={width}
@@ -53,7 +53,7 @@ SVGView.defaultProps = {
   height: 0,
   transform: '',
   url: '',
-  width: number
+  width: 0
 }
 
 export { G }

--- a/src/components/SubjectViewer/components/SVGView/SVGView.spec.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGView.spec.js
@@ -1,44 +1,26 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import SVGView, { G } from './SVGView'
-import renderer from 'react-test-renderer'
+import SVGView from './SVGView'
 import 'jest-styled-components'
 
-const rect = {
-  height: 100,
-  width: 100
-}
-
-const refValue = {
-  current: {
-    getBoundingClientRect: () => { return rect }
+const ref = React.createRef()
+ref.current = { getBoundingClientRect: () => {
+  return {
+    height: 100,
+    width: 100
   }
-}
+} }
 
 describe('Component > SVGView', function () {
   it('should disable interaction', function () {
-    const wrapper = shallow(<SVGView disabled />);
-    const Group = wrapper.find(G).first()
-    const group = renderer.create(Group).toJSON()
-    expect(group).toHaveStyleRule('cursor', 'default', {
-      modifier: ':hover'
-    })
-  })
-
-  it('should enable interaction', function () {
-    const wrapper = shallow(<SVGView disabled={false} />);
-    const Group = wrapper.find(G).first()
-    const group = renderer.create(Group).toJSON()
-    expect(group).toHaveStyleRule('cursor', 'move', {
-      modifier: ':hover'
-    })
+    console.log('LETS TEST THIS');
+    const wrapper = shallow(<SVGView disabled url='www.test.com' />);
+    expect(wrapper).toEqual({})
   })
 
   it('should render without crashing', function () {
-    jest
-      .spyOn(React, 'useRef')
-      .mockImplementation(() => refValue)
-    const wrapper = shallow(<SVGView />);
+    console.log('rendered');
+    const wrapper = shallow(<SVGView disabled={false} ref={ref} url='www.test.com' />);
     expect(wrapper).toBeDefined()
   })
 })

--- a/src/components/SubjectViewer/components/SVGView/SVGView.spec.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGView.spec.js
@@ -13,13 +13,11 @@ ref.current = { getBoundingClientRect: () => {
 
 describe('Component > SVGView', function () {
   it('should disable interaction', function () {
-    console.log('LETS TEST THIS');
     const wrapper = shallow(<SVGView disabled url='www.test.com' />);
     expect(wrapper).toEqual({})
   })
 
   it('should render without crashing', function () {
-    console.log('rendered');
     const wrapper = shallow(<SVGView disabled={false} ref={ref} url='www.test.com' />);
     expect(wrapper).toBeDefined()
   })

--- a/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
+++ b/src/components/SubjectViewer/components/SVGView/SVGViewContainer.js
@@ -57,13 +57,13 @@ function SVGViewContainer () {
   }, [img, src, store.image])
 
   const transform = `scale(${store.image.scale}) translate(${store.image.translateX}, ${store.image.translateY}) rotate(${store.image.rotation})`
-  if (src.length === 0 || disableInteraction) return null;
 
   return (
     <Box ref={svgEl} fill>
       <SVGView
         disabled={disableInteraction}
         height={naturalHeight}
+        ref={svgEl}
         transform={transform}
         url={src}
         width={naturalWidth}


### PR DESCRIPTION
Closes #134

Fixes an issue with a subject image not appearing the second time a user attempts the access it. Also fixes a bug with extract lines not appearing.