### PR TITLE
Fix Inconsistencies Between Browsers

### DIFF
--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -21,7 +21,6 @@ const CapitalText = styled(Text)`
 `
 
 const StyledTable = styled(Table)`
-  margin-top: 2em;
   table-layout: fixed;
 `
 
@@ -79,20 +78,20 @@ function MetadataButton({
           target={targetEl.current}
         >
           <Box background='white' height='large' overflow='hidden' width='large'>
-            <Box pad='small'>
+            <Box basis='20%' pad='small'>
               <Box direction='row' justify='between'>
                 <Text size='large'>{`Subject ${id}`}</Text>
                 <Button onClick={() => {toggleDrop(false) }} plain>
                   <FontAwesomeIcon icon={faTimesCircle} size='xs' />
                 </Button>
               </Box>
-              <Box margin={{ top: 'medium' }}>
+              <Box>
                 <CapitalText size='xsmall'>
                   {pages} pages &#8226; {transcribers}/{goldStandard} transcribers/gold standard &#8226; {lines} transcribed lines &#8226; {score}/{transcribers} average consensus &#8226; {status}
                 </CapitalText>
               </Box>
             </Box>
-            <Box margin={{ top: 'medium' }} overflow={{ vertical: 'scroll' }} width='100%'>
+            <Box basis='80%' overflow={{ vertical: 'scroll' }} width='100%'>
               <StyledTable>
                 <colgroup>
                   <col width="33%" />

--- a/src/components/EditorHeader/components/Title/Title.js
+++ b/src/components/EditorHeader/components/Title/Title.js
@@ -55,7 +55,7 @@ function Title({ history, match, onEditor }) {
     `(${store.transcriptions.approvedCount}/${store.transcriptions.all.size} approved)` : ''
   return (
     <Box align='baseline'>
-      <Box direction='row'>
+      <Box direction='row' wrap>
         {titles.reverse().map((sub, i) => {
           const nextSub = titles[i+1]
           const removeSlash = i === titles.length - 1 || nextSub.title.length === 0

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -11,10 +11,7 @@ import styled from 'styled-components'
 
 export const StyledDataTable = styled(DataTable)`
   width: 100%;
-
-  @-moz-document url-prefix() {
-    table-layout: auto;
-  }
+  table-layout: auto;
 `
 
 function ResourcesTable(props) {

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -10,7 +10,9 @@ import SearchTags from './components/SearchTags'
 import styled from 'styled-components'
 
 const StyledDataTable = styled(DataTable)`
-  display: block;
+  @-moz-document url-prefix() {
+    display: block
+  }
 `
 
 function ResourcesTable(props) {

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -7,6 +7,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import StepNavigation from '../StepNavigation'
 import SearchTags from './components/SearchTags'
+import styled from 'styled-components'
+
+const StyledDataTable = styled(DataTable)`
+  display: block;
+`
 
 function ResourcesTable(props) {
   const onClickRow = (e) => {
@@ -19,11 +24,18 @@ function ResourcesTable(props) {
   }
 
   return (
-    <Box background='white' fill='horizontal' margin={{ vertical: 'small' }} pad='medium' round='xsmall'>
+    <Box
+      background='white'
+      fill='horizontal'
+      margin={{ vertical: 'small' }}
+      overflow={{ horizontal: 'auto' }}
+      pad='medium'
+      round='xsmall'
+    >
       {props.searching && <SearchTags />}
 
       {props.data.length > 0 &&
-        <DataTable
+        <StyledDataTable
           columns={[...props.columns].map(col => ({ ...col }))}
           data={props.data}
           onClickRow={onClickRow}

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -10,8 +10,10 @@ import SearchTags from './components/SearchTags'
 import styled from 'styled-components'
 
 export const StyledDataTable = styled(DataTable)`
+  width: 100%;
+
   @-moz-document url-prefix() {
-    display: block
+    table-layout: auto;
   }
 `
 

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -9,7 +9,7 @@ import StepNavigation from '../StepNavigation'
 import SearchTags from './components/SearchTags'
 import styled from 'styled-components'
 
-const StyledDataTable = styled(DataTable)`
+export const StyledDataTable = styled(DataTable)`
   @-moz-document url-prefix() {
     display: block
   }

--- a/src/components/ResourcesTable/ResourcesTable.spec.js
+++ b/src/components/ResourcesTable/ResourcesTable.spec.js
@@ -1,8 +1,8 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { DataTable, Text } from 'grommet'
+import { Text } from 'grommet'
 import ASYNC_STATES from 'helpers/asyncStates'
-import { ResourcesTable } from './ResourcesTable'
+import { ResourcesTable, StyledDataTable } from './ResourcesTable'
 import SearchTags from './components/SearchTags'
 
 let wrapper;
@@ -77,7 +77,7 @@ describe('ResourcesTable functions', function () {
       datum: { link: '/123' },
       target: { type: 'box' }
     }
-    const table = wrapper.find(DataTable).first().props()
+    const table = wrapper.find(StyledDataTable).first().props()
     table.onClickRow(mockEvent)
     expect(pushSpy).toHaveBeenCalledWith('/projects/123')
   })
@@ -93,7 +93,7 @@ describe('ResourcesTable onSelection prop', function () {
       datum: { link: '/123' },
       target: { type: 'box' }
     }
-    const table = wrapper.find(DataTable).first().props()
+    const table = wrapper.find(StyledDataTable).first().props()
     table.onClickRow(mockEvent)
     expect(onSelectionSpy).toHaveBeenCalledWith(mockEvent.datum)
   })


### PR DESCRIPTION
This PR just fixes three UI issues:
- Allows the title/breadcrumb component to wrap on narrow screens fixing a problem on all browsers (fig 1)
- Fixes a Firefox transcription table overflow issue (fig 2)
- Fixes a Safari issue where the metadata close button to the right of container isn't present (fig 3)

Closes #146 

_Fig 1_
<img width="231" alt="Screen Shot 2020-04-16 at 2 27 26 PM" src="https://user-images.githubusercontent.com/14099077/79498193-85165a00-7fee-11ea-9d0e-7a002c0e9623.png">

_Fig 2_
<img width="519" alt="Screen Shot 2020-04-16 at 2 29 21 PM" src="https://user-images.githubusercontent.com/14099077/79498309-b42ccb80-7fee-11ea-8557-eb9234e010a6.png">

_Fig 3_
<img width="766" alt="Screen Shot 2020-04-16 at 2 31 22 PM" src="https://user-images.githubusercontent.com/14099077/79498459-f9e99400-7fee-11ea-866b-4e9f2a93c01f.png">


You can see the current issues at [alice.preview.zooniverse.org](alice.preview.zooniverse.org)