### PR TITLE
Fix bug when searching by Zooniverse id

### DIFF
--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -92,7 +92,7 @@ const SearchStore = types.model('SearchStore', {
   fetchTranscriptionsById: function fetchTranscriptionsById() {
     const transcriptions = getRoot(self).transcriptions
     transcriptions.reset()
-    const searchType = self.type === TYPES.ZOONIVERSE ? 'subject_id' : 'internal_id'
+    const searchType = self.type === TYPES.ZOONIVERSE ? 'id' : 'internal_id'
     const filterType = self.type === TYPES.ZOONIVERSE ? '_eq' : '_cont'
     return `filter[${searchType}${filterType}]=${self.id}`
   },

--- a/src/store/SearchStore.spec.js
+++ b/src/store/SearchStore.spec.js
@@ -41,12 +41,12 @@ describe('SearchStore', function () {
     expect(searchStore.getSearchQuery()).toBe(`&filter[status_in]=unseen&filter[low_consensus_eq]=true`)
   })
 
-  it('should searchTranscriptions and fetch by subject_id', function() {;
+  it('should searchTranscriptions and fetch by subject id', function() {;
     searchStore.searchTranscriptions({ id: '1', type: 'ZOONIVERSE ID' })
     expect(searchStore.id).toBe('1')
     expect(searchStore.type).toBe('ZOONIVERSE ID')
     expect(fetchTranscriptionsSpy).toHaveBeenCalled()
-    expect(searchStore.getSearchQuery()).toBe(`&filter[subject_id_eq]=1`)
+    expect(searchStore.getSearchQuery()).toBe(`&filter[id_eq]=1`)
   })
 
   it('should searchTranscriptions and fetch by internal_id', function() {;


### PR DESCRIPTION
The search modal was incorrectly pinging the TOVE db for `subject_id`, which doesn't exist. Instead, `id` should work here since TOVE transcription IDs map exactly to Panoptes subjects