### PR TITLE
Allow Transcription Dates to Appear

### DIFF
--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -51,7 +51,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   function arrangeExtractsByUser() {
     return self.rawExtracts.reduce((list, extract) => {
       if (!list[extract.user_id]) list[extract.user_id] = []
-      list[extract.user_id].push({ ...extract.data, time: extract.classificationAt })
+      list[extract.user_id].push({ ...extract.data, time: extract.time })
       return list
     }, {})
   }
@@ -182,7 +182,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     yield request(config.caesar, query).then((data) => {
       const filteredExtracts = data.workflow.extracts.filter(extract => Object.entries(extract.data).length > 0)
       validExtracts = filteredExtracts.map((extract) => {
-        return { data: extract.data, user_id: extract.userId }
+        return { data: extract.data, user_id: extract.userId, time: extract.classificationAt }
       })
     })
     undoManager.withoutUndo(() => self.rawExtracts = validExtracts)

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -41,13 +41,15 @@ const getToveResponseByAUser = () => Promise.resolve(
   }
 )
 
+const extract = {
+  data: mockExtract,
+  userId: '123',
+  classificationAt: 1515450629.237
+}
+
 const extracts = {
   workflow: {
-    extracts: [{
-      data: mockExtract,
-      userId: '123',
-      classificationAt: 1515450629.237
-    }]
+    extracts: [extract]
   }
 }
 
@@ -234,6 +236,13 @@ describe('TranscriptionsStore', function () {
       it('should return current transcription views', function () {
         expect(transcriptionsStore.approved).toBe(false)
         expect(transcriptionsStore.title).toBe('1')
+      })
+
+      it('should correctly set the raw extracts', function () {
+        const rawExtract = transcriptionsStore.rawExtracts[0]
+        expect(rawExtract.time).toEqual(extract.classificationAt)
+        expect(rawExtract.user_id).toEqual(extract.userId)
+        expect(rawExtract.data).toEqual(extract.data)
       })
 
       it('should set an active transcription', function () {


### PR DESCRIPTION
Oops, looks like the extracts were borked at some point and aren't showing the correct transcription time (see below). This turned out to be an issue with the data saved correctly in the store. 

<img width="289" alt="Screen Shot 2020-04-24 at 11 57 32 AM" src="https://user-images.githubusercontent.com/14099077/80237720-d04def80-8622-11ea-8923-563638797465.png">