### PR TITLE
Rearrange Pages By Slope Values

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -520,7 +520,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
         </button>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 ekjAwv"
+        className="StyledBox-sc-13pk1d4-0 ilHtzj"
       />
     </div>
   </div>

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box, Text } from 'grommet'
 import styled from 'styled-components'
-import { arrayOf, bool, shape, func } from 'prop-types'
+import { arrayOf, bool, number, shape, func } from 'prop-types'
 import { observer } from 'mobx-react'
 import TranscriptionTableRow from './TranscriptionTableRow'
 
@@ -72,12 +72,14 @@ function TranscriptionTable ({ activeSlope, data, isViewer, setActiveTranscripti
 }
 
 TranscriptionTable.propTypes = {
+  activeSlope: number,
   data: arrayOf(shape()),
   isViewer: bool,
   setActiveTranscription: func
 }
 
 TranscriptionTable.defaultProps = {
+  activeSlope: 0,
   data: [],
   isViewer: false,
   setActiveTranscription: () => {}

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
@@ -20,7 +20,7 @@ const RightAlignText = styled(StyledText)`
   text-align: end;
 `
 
-function TranscriptionTable ({ data, isViewer, setActiveTranscription, setTextObject }) {
+function TranscriptionTable ({ activeSlope, data, isViewer, setActiveTranscription, setTextObject }) {
   const [dataArray, resetDataArray] = React.useState(data)
   const [dragID, setDragID] = React.useState(null)
   const emptyData = data.length === 0
@@ -45,6 +45,7 @@ function TranscriptionTable ({ data, isViewer, setActiveTranscription, setTextOb
       </Box>
       <Box pad={{ bottom: 'xsmall' }}>
         {dataArray.map((datum, i) => {
+          if (activeSlope !== datum.line_slope) return null
           return (
             <TranscriptionTableRow
               data={dataArray}

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.spec.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.spec.js
@@ -23,6 +23,11 @@ describe('Component > TranscriptionTable', function () {
     expect(mockData.length).toEqual(wrapper.find(TranscriptionTableRow).length)
   })
 
+  it('should hide rows without a matching slope', function () {
+    wrapper = shallow(<TranscriptionTable activeSlope={90} data={mockData} />);
+    expect(0).toEqual(wrapper.find(TranscriptionTableRow).length)
+  })
+
   describe('useEffect hook', function () {
     it('should reset the data array with a null dragID', function () {
       const setStateSpy = jest.fn()

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableContainer.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableContainer.js
@@ -11,6 +11,7 @@ function TranscriptionTableContainer() {
 
   return (
     <TranscriptionTable
+      activeSlope={store.transcriptions.activeSlope}
       data={frameData}
       isViewer={store.projects.isViewer}
       setActiveTranscription={setActiveTranscription}

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableContainer.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableContainer.js
@@ -5,8 +5,7 @@ import TranscriptionTable from './TranscriptionTable'
 
 function TranscriptionTableContainer() {
   const store = React.useContext(AppContext)
-  const transcriptionData = store.transcriptions.current && store.transcriptions.current.text
-  const frameData = (transcriptionData && transcriptionData.get(`frame${store.transcriptions.index}`)) || []
+  const frameData = store.transcriptions.currentTranscriptions || []
   const setActiveTranscription = id => store.transcriptions.setActiveTranscription(id);
 
   return (

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/mockData.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/mockData.js
@@ -5,7 +5,8 @@ const data = [
     flagged: false,
     counts: 3,
     consensus: 14,
-    goldStandard: false
+    goldStandard: false,
+    line_slope: 0
   },
   {
     transcription: 'vulputate leo. Vivamus venenatis, massa ut placerat porttitor, tellus ex mattis ipsum, nec',
@@ -13,7 +14,8 @@ const data = [
     flagged: false,
     counts: 4,
     consensus: 4,
-    goldStandard: false
+    goldStandard: false,
+    line_slope: 0
   },
   {
     transcription: 'sagittis sapien erat ac nisi. Curabitur nulla erat, blandit at elementum eget, lobortis ac magna.',
@@ -21,7 +23,8 @@ const data = [
     flagged: false,
     counts: 12,
     consensus: 12,
-    goldStandard: false
+    goldStandard: false,
+    line_slope: 0
   },
   {
     transcription: 'Praesent vel dolor tempus, posuere massa sit amet, imperdiet massa. Donec tortor sapien,',
@@ -29,7 +32,8 @@ const data = [
     flagged: false,
     counts: 3,
     consensus: 14,
-    goldStandard: true
+    goldStandard: true,
+    line_slope: 0
   },
   {
     transcription: 'cursus sagittis pulvinar non, tristique imperdiet orci. In consequat sed erat eleifend efficitur.',
@@ -37,7 +41,8 @@ const data = [
     flagged: false,
     counts: 4,
     consensus: 4,
-    goldStandard: false
+    goldStandard: false,
+    line_slope: 0
   },
   {
     transcription: 'Integer odio sapien, fermentum ut elit ut, dapibus congue est. Etiam egestas quis nisi',
@@ -45,7 +50,8 @@ const data = [
     flagged: true,
     counts: 12,
     consensus: 12,
-    goldStandard: true
+    goldStandard: true,
+    line_slope: 0
   },
   {
     transcription: 'vehicula ultricies. Donec rhoncus ut nibh sit amet convallis. Morbi aliquet at lorem a',
@@ -53,7 +59,8 @@ const data = [
     flagged: false,
     counts: 3,
     consensus: 14,
-    goldStandard: false
+    goldStandard: false,
+    line_slope: 0
   },
   {
     transcription: 'imperdiet. Proin lorem metus, tristique et pellentesque non, luctus sed urna.',
@@ -61,128 +68,9 @@ const data = [
     flagged: true,
     counts: 4,
     consensus: 4,
-    goldStandard: false
-  },
-  {
-    transcription: 'Mauris elementum pulvinar lacinia. Donec tincidunt pretium quam, at condimentum ex lacinia',
-    reviewed: false,
-    flagged: false,
-    counts: 4,
-    consensus: 4,
-    goldStandard: false
-  },
-  {
-    transcription: 'eu. Fusce vel leo massa. Integer porttitor rutrum lorem, non lobortis mauris tincidunt at. ',
-    reviewed: false,
-    flagged: false,
-    counts: 3,
-    consensus: 14,
-    goldStandard: true
-  },
-  {
-    transcription: 'Pellentesque maximus sodales urna vitae imperdiet. Quisque hendrerit porttitor leo ut',
-    reviewed: false,
-    flagged: false,
-    counts: 4,
-    consensus: 4,
-    goldStandard: false
-  },
-  {
-    transcription: 'imperdiet. Ut ullamcorper ex vitae venenatis scelerisque. Vestibulum euismod, ex in sagittis',
-    reviewed: false,
-    flagged: false,
-    counts: 3,
-    consensus: 14,
-    goldStandard: true
-  },
-  {
-    transcription: 'cursus, augue erat pharetra diam, condimentum placerat risus risus nec risus. Etiam massa',
-    reviewed: false,
-    flagged: false,
-    counts: 1,
-    consensus: 4,
-    goldStandard: false
-  },
-  {
-    transcription: 'quam, tincidunt eu tortor semper, pharetra luctus mi. Cras pretium velit non vestibulum',
-    reviewed: false,
-    flagged: true,
-    counts: 12,
-    consensus: 12,
-    goldStandard: false
-  },
-  {
-    transcription: 'finibus. Proin vitae ornare massa. Ut efficitur mattis consectetur.',
-    reviewed: false,
-    flagged: false,
-    counts: 3,
-    consensus: 14,
-    goldStandard: false
-  },
-  {
-    transcription: 'Vestibulum vestibulum tempus risus sit amet varius. Phasellus quis ante rhoncus lectus',
-    reviewed: false,
-    flagged: false,
-    counts: 4,
-    consensus: 4,
-    goldStandard: false
-  },
-  {
-    transcription: 'suscipit aliquam. Suspendisse luctus sapien eu magna condimentum mollis.',
-    reviewed: false,
-    flagged: false,
-    counts: 12,
-    consensus: 12,
-    goldStandard: false
-  },
-  {
-    transcription: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam sit amet sagittis arcu la erat,',
-    reviewed: true,
-    flagged: false,
-    counts: 12,
-    consensus: 12,
-    goldStandard: false
-  },
-  {
-    transcription: 'blandit at elementum eget, lobortis ac magna. Praesent vel dolor tempus, posuere massa sit',
-    reviewed: true,
-    flagged: false,
-    counts: 3,
-    consensus: 14,
-    goldStandard: false
-  },
-  {
-    transcription: 'amet, imperdiet massa. Donec tortor sapien, cursus sagittis pulvinar non, tristique imperdiet',
-    reviewed: false,
-    flagged: false,
-    counts: 4,
-    consensus: 4,
-    goldStandard: false
-  },
-  {
-    transcription: 'orci. In consequat sed erat eleifend efficitur. Integer odio sapien, fermentum ut elit ut,',
-    reviewed: false,
-    flagged: false,
-    counts: 12,
-    consensus: 12,
-    goldStandard: false
-  },
-  {
-    transcription: 'dapibus congue est. Etiam egestas quis nisi vehicula ultricies. Donec rhoncus ut nibh sit amet ',
-    reviewed: false,
-    flagged: false,
-    counts: 3,
-    consensus: 3,
-    goldStandard: false
-  },
-  {
-    transcription: 'convallis. Morbi aliquet at lorem a imperdiet. Proin lorem metus, tristique et pellentesque non, luctus ',
-    reviewed: false,
-    flagged: false,
-    counts: 3,
-    consensus: 3,
-    goldStandard: false
-  },
+    goldStandard: false,
+    line_slope: 0
+  }
 ];
 
 export default data

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -2,7 +2,9 @@ import React from 'react'
 import { Box, Button, Text } from 'grommet'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
+import { observer } from 'mobx-react'
 import { FormDown, FormUp } from 'grommet-icons'
+import { getPage } from 'helpers/slopeHelpers'
 import FilmstripThumbnail from './components/FilmstripThumbnail'
 import StepNavigation from '../StepNavigation'
 import Overlay from '../Overlay'
@@ -15,8 +17,18 @@ const RelativeBox = styled(Box)`
   position: relative;
 `
 
-function FilmstripViewer ({ disabled, selectImage, subjectIndex, images, isOpen, setOpen }) {
+function FilmstripViewer ({
+  disabled,
+  images,
+  isOpen,
+  selectImage,
+  setOpen,
+  slopeKeys,
+  subjectIndex
+}) {
   const actionText = isOpen ? 'Collapse' : 'Expand';
+  const [slopeValues, setSlopeValues] = React.useState(slopeKeys)
+  const [hoveredIndex, setHoveredIndex] = React.useState()
 
   return (
     <RelativeBox background='#FFFFFF' pad='xsmall' round={{ size: 'xsmall', corner: 'top' }}>
@@ -40,16 +52,24 @@ function FilmstripViewer ({ disabled, selectImage, subjectIndex, images, isOpen,
           reverse />
       </Box>
       {isOpen && (
-          <Box direction='row'>
-            {images.map((image, i) => {
-              const isActive = i === subjectIndex
+          <Box direction='row' wrap>
+            {slopeValues.map((key, i) => {
+              const page = parseInt(getPage(key))
+              const image = images[page]
+              const isActive = page === subjectIndex
               return (
                 <FilmstripThumbnail
                   key={`THUMBNAIL_${i}`}
                   disabled={disabled}
+                  hoveredIndex={hoveredIndex}
                   index={i}
                   isActive={isActive}
+                  page={page}
                   selectImage={selectImage}
+                  setHoveredIndex={setHoveredIndex}
+                  setSlopeValues={setSlopeValues}
+                  slopeKey={key}
+                  slopeValues={slopeValues}
                   src={image}
                 />)
             })}
@@ -77,4 +97,4 @@ FilmstripViewer.propTypes = {
   subjectIndex: PropTypes.number
 }
 
-export default FilmstripViewer
+export default observer(FilmstripViewer)

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -96,6 +96,7 @@ FilmstripViewer.defaultProps = {
   isOpen: true,
   selectImage: () => {},
   setOpen: () => {},
+  slopeKeys: [],
   subjectIndex: 0
 }
 
@@ -105,6 +106,7 @@ FilmstripViewer.propTypes = {
   isOpen: PropTypes.bool,
   selectImage: PropTypes.func,
   setOpen: PropTypes.func,
+  slopeKeys: PropTypes.arrayOf(PropTypes.string),
   subjectIndex: PropTypes.number
 }
 

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -62,7 +62,6 @@ function FilmstripViewer ({
               const isActive = page === subjectIndex && slopeIndex === activeSlope
               const slopeDefinition = slopeDefinitions[key]
               const border = spotInGroup(slopeValues, i)
-              console.log(border);
 
               return (
                 <Box border={border} key={`THUMBNAIL_${i}`} margin={{ bottom: 'xsmall' }}>

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { observer } from 'mobx-react'
 import { FormDown, FormUp } from 'grommet-icons'
-import { getPage } from 'helpers/slopeHelpers'
+import { getPage, getSlopeLabel } from 'helpers/slopeHelpers'
 import FilmstripThumbnail from './components/FilmstripThumbnail'
 import StepNavigation from '../StepNavigation'
 import Overlay from '../Overlay'
@@ -18,6 +18,7 @@ const RelativeBox = styled(Box)`
 `
 
 function FilmstripViewer ({
+  activeSlope,
   disabled,
   images,
   isOpen,
@@ -54,9 +55,10 @@ function FilmstripViewer ({
       {isOpen && (
           <Box direction='row' wrap>
             {slopeValues.map((key, i) => {
-              const page = parseInt(getPage(key))
+              const page = getPage(key)
+              const slopeIndex = getSlopeLabel(key)
               const image = images[page]
-              const isActive = page === subjectIndex
+              const isActive = page === subjectIndex && slopeIndex === activeSlope
               return (
                 <FilmstripThumbnail
                   key={`THUMBNAIL_${i}`}
@@ -68,6 +70,7 @@ function FilmstripViewer ({
                   selectImage={selectImage}
                   setHoveredIndex={setHoveredIndex}
                   setSlopeValues={setSlopeValues}
+                  slopeIndex={slopeIndex}
                   slopeKey={key}
                   slopeValues={slopeValues}
                   src={image}

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -25,14 +25,14 @@ function FilmstripViewer ({
   rearrangePages,
   selectImage,
   setOpen,
+  setSlopeKeys,
   slopeDefinitions,
   slopeKeys,
   subjectIndex
 }) {
   const actionText = isOpen ? 'Collapse' : 'Expand';
-  const [slopeValues, setSlopeValues] = React.useState(slopeKeys)
   const [hoveredIndex, setHoveredIndex] = React.useState()
-  const handlePageRearrangement = () => rearrangePages(slopeValues)
+  const handlePageRearrangement = () => rearrangePages(slopeKeys)
 
   return (
     <RelativeBox background='#FFFFFF' pad='xsmall' round={{ size: 'xsmall', corner: 'top' }}>
@@ -57,13 +57,13 @@ function FilmstripViewer ({
       </Box>
       {isOpen && (
           <Box direction='row' wrap>
-            {slopeValues.map((key, i) => {
+            {slopeKeys.map((key, i) => {
               const page = getPage(key)
               const slopeIndex = getSlopeLabel(key)
               const image = images[page]
               const isActive = page === subjectIndex && slopeIndex === activeSlope
               const slopeDefinition = slopeDefinitions[key]
-              const border = spotInGroup(slopeValues, i)
+              const border = spotInGroup(slopeKeys, i)
 
               return (
                 <Box border={border} key={`THUMBNAIL_${i}`} margin={{ bottom: 'xsmall' }}>
@@ -76,10 +76,10 @@ function FilmstripViewer ({
                     rearrangePages={handlePageRearrangement}
                     selectImage={selectImage}
                     setHoveredIndex={setHoveredIndex}
-                    setSlopeValues={setSlopeValues}
+                    setSlopeValues={setSlopeKeys}
                     slopeDefinition={slopeDefinition}
                     slopeIndex={slopeIndex}
-                    slopeValues={slopeValues}
+                    slopeValues={slopeKeys}
                     src={image}
                   />
                 </Box>)
@@ -96,6 +96,7 @@ FilmstripViewer.defaultProps = {
   isOpen: true,
   selectImage: () => {},
   setOpen: () => {},
+  setSlopeKeys: () => {},
   slopeKeys: [],
   subjectIndex: 0
 }
@@ -106,6 +107,7 @@ FilmstripViewer.propTypes = {
   isOpen: PropTypes.bool,
   selectImage: PropTypes.func,
   setOpen: PropTypes.func,
+  setSlopeKeys: PropTypes.func,
   slopeKeys: PropTypes.arrayOf(PropTypes.string),
   subjectIndex: PropTypes.number
 }

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -3,6 +3,7 @@ import { Box, Button, Text } from 'grommet'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { observer } from 'mobx-react'
+import isEqual from 'helpers/isEqual'
 import { FormDown, FormUp } from 'grommet-icons'
 import { spotInGroup, getPage, getSlopeLabel } from 'helpers/slopeHelpers'
 import FilmstripThumbnail from './components/FilmstripThumbnail'
@@ -17,6 +18,17 @@ const RelativeBox = styled(Box)`
   position: relative;
 `
 
+function usePrevious(rawValue) {
+  const value = rawValue.map(l => l)
+  const ref = React.useRef();
+
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
+
 function FilmstripViewer ({
   activeSlope,
   disabled,
@@ -25,14 +37,20 @@ function FilmstripViewer ({
   rearrangePages,
   selectImage,
   setOpen,
-  setSlopeKeys,
   slopeDefinitions,
   slopeKeys,
   subjectIndex
 }) {
   const actionText = isOpen ? 'Collapse' : 'Expand';
   const [hoveredIndex, setHoveredIndex] = React.useState()
-  const handlePageRearrangement = () => rearrangePages(slopeKeys)
+  const [slopeValues, setSlopeValues] = React.useState(slopeKeys)
+  const previous = usePrevious(slopeKeys)
+
+  if (!isEqual(previous, slopeKeys) && slopeKeys !== slopeValues) {
+    setSlopeValues(slopeKeys)
+  }
+
+  const handlePageRearrangement = () => rearrangePages(slopeValues)
 
   return (
     <RelativeBox background='#FFFFFF' pad='xsmall' round={{ size: 'xsmall', corner: 'top' }}>
@@ -57,13 +75,13 @@ function FilmstripViewer ({
       </Box>
       {isOpen && (
           <Box direction='row' wrap>
-            {slopeKeys.map((key, i) => {
+            {slopeValues.map((key, i) => {
               const page = getPage(key)
               const slopeIndex = getSlopeLabel(key)
               const image = images[page]
               const isActive = page === subjectIndex && slopeIndex === activeSlope
               const slopeDefinition = slopeDefinitions[key]
-              const border = spotInGroup(slopeKeys, i)
+              const border = spotInGroup(slopeValues, i)
 
               return (
                 <Box border={border} key={`THUMBNAIL_${i}`} margin={{ bottom: 'xsmall' }}>
@@ -76,10 +94,10 @@ function FilmstripViewer ({
                     rearrangePages={handlePageRearrangement}
                     selectImage={selectImage}
                     setHoveredIndex={setHoveredIndex}
-                    setSlopeValues={setSlopeKeys}
+                    setSlopeValues={setSlopeValues}
                     slopeDefinition={slopeDefinition}
                     slopeIndex={slopeIndex}
-                    slopeValues={slopeKeys}
+                    slopeValues={slopeValues}
                     src={image}
                   />
                 </Box>)

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -22,6 +22,7 @@ function FilmstripViewer ({
   disabled,
   images,
   isOpen,
+  rearrangePages,
   selectImage,
   setOpen,
   slopeDefinitions,
@@ -31,6 +32,7 @@ function FilmstripViewer ({
   const actionText = isOpen ? 'Collapse' : 'Expand';
   const [slopeValues, setSlopeValues] = React.useState(slopeKeys)
   const [hoveredIndex, setHoveredIndex] = React.useState()
+  const handlePageRearrangement = () => rearrangePages(slopeValues)
 
   return (
     <RelativeBox background='#FFFFFF' pad='xsmall' round={{ size: 'xsmall', corner: 'top' }}>
@@ -71,12 +73,12 @@ function FilmstripViewer ({
                     index={i}
                     isActive={isActive}
                     page={page}
+                    rearrangePages={handlePageRearrangement}
                     selectImage={selectImage}
                     setHoveredIndex={setHoveredIndex}
                     setSlopeValues={setSlopeValues}
                     slopeDefinition={slopeDefinition}
                     slopeIndex={slopeIndex}
-                    slopeKey={key}
                     slopeValues={slopeValues}
                     src={image}
                   />

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -24,6 +24,7 @@ function FilmstripViewer ({
   isOpen,
   selectImage,
   setOpen,
+  slopeDefinitions,
   slopeKeys,
   subjectIndex
 }) {
@@ -59,6 +60,7 @@ function FilmstripViewer ({
               const slopeIndex = getSlopeLabel(key)
               const image = images[page]
               const isActive = page === subjectIndex && slopeIndex === activeSlope
+              const slopeDefinition = slopeDefinitions[key]
               return (
                 <FilmstripThumbnail
                   key={`THUMBNAIL_${i}`}
@@ -70,6 +72,7 @@ function FilmstripViewer ({
                   selectImage={selectImage}
                   setHoveredIndex={setHoveredIndex}
                   setSlopeValues={setSlopeValues}
+                  slopeDefinition={slopeDefinition}
                   slopeIndex={slopeIndex}
                   slopeKey={key}
                   slopeValues={slopeValues}

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { observer } from 'mobx-react'
 import { FormDown, FormUp } from 'grommet-icons'
-import { getPage, getSlopeLabel } from 'helpers/slopeHelpers'
+import { spotInGroup, getPage, getSlopeLabel } from 'helpers/slopeHelpers'
 import FilmstripThumbnail from './components/FilmstripThumbnail'
 import StepNavigation from '../StepNavigation'
 import Overlay from '../Overlay'
@@ -61,23 +61,27 @@ function FilmstripViewer ({
               const image = images[page]
               const isActive = page === subjectIndex && slopeIndex === activeSlope
               const slopeDefinition = slopeDefinitions[key]
+              const border = spotInGroup(slopeValues, i)
+              console.log(border);
+
               return (
-                <FilmstripThumbnail
-                  key={`THUMBNAIL_${i}`}
-                  disabled={disabled}
-                  hoveredIndex={hoveredIndex}
-                  index={i}
-                  isActive={isActive}
-                  page={page}
-                  selectImage={selectImage}
-                  setHoveredIndex={setHoveredIndex}
-                  setSlopeValues={setSlopeValues}
-                  slopeDefinition={slopeDefinition}
-                  slopeIndex={slopeIndex}
-                  slopeKey={key}
-                  slopeValues={slopeValues}
-                  src={image}
-                />)
+                <Box border={border} key={`THUMBNAIL_${i}`} margin={{ bottom: 'xsmall' }}>
+                  <FilmstripThumbnail
+                    disabled={disabled}
+                    hoveredIndex={hoveredIndex}
+                    index={i}
+                    isActive={isActive}
+                    page={page}
+                    selectImage={selectImage}
+                    setHoveredIndex={setHoveredIndex}
+                    setSlopeValues={setSlopeValues}
+                    slopeDefinition={slopeDefinition}
+                    slopeIndex={slopeIndex}
+                    slopeKey={key}
+                    slopeValues={slopeValues}
+                    src={image}
+                  />
+                </Box>)
             })}
           </Box>
       )}

--- a/src/components/FilmstripViewer/FilmstripViewer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.spec.js
@@ -14,6 +14,14 @@ import Overlay from '../Overlay'
 
 let wrapper;
 let setOpen
+const slopeDefinitions = {
+  'frame0.0': '0',
+  'frame1.0': '90',
+  'frame2.0': '0',
+  'frame3.0': '0',
+  'frame4.0': '0',
+  'frame5.0': '0',
+}
 
 describe('Component > FilmstripViewer', function () {
   beforeEach(function() {
@@ -22,6 +30,8 @@ describe('Component > FilmstripViewer', function () {
       <FilmstripViewer
         images={[Page1, Page2, Page3, Page4, Page5, Page6]}
         setOpen={setOpen}
+        slopeDefinitions={slopeDefinitions}
+        slopeKeys={['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0', 'frame4.0', 'frame5.0']}
       />)
   })
 

--- a/src/components/FilmstripViewer/FilmstripViewer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.spec.js
@@ -23,15 +23,20 @@ const slopeDefinitions = {
   'frame5.0': '0',
 }
 
+const slopeKeys = ['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0', 'frame4.0', 'frame5.0']
+
 describe('Component > FilmstripViewer', function () {
   beforeEach(function() {
     setOpen = jest.fn()
+    jest
+      .spyOn(React, 'useState')
+      .mockImplementation((init) => [init, jest.fn()])
     wrapper = shallow(
       <FilmstripViewer
         images={[Page1, Page2, Page3, Page4, Page5, Page6]}
         setOpen={setOpen}
         slopeDefinitions={slopeDefinitions}
-        slopeKeys={['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0', 'frame4.0', 'frame5.0']}
+        slopeKeys={slopeKeys}
       />)
   })
 
@@ -59,5 +64,14 @@ describe('Component > FilmstripViewer', function () {
   it('should show an overlay when disabled', function () {
     wrapper = shallow(<FilmstripViewer disabled />)
     expect(wrapper.find(Overlay).length).toBe(1)
+  })
+
+  it('should reset slopeValues if slopeKeys change', function () {
+    const newKeys = slopeKeys.slice()
+    newKeys.push('frame0.1')
+    wrapper.setProps({ slopeKeys: newKeys })
+    wrapper.update()
+    const thumbnailLength = wrapper.find(FilmstripThumbnail).length
+    expect(thumbnailLength).toBe(7)
   })
 })

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -21,7 +21,6 @@ function FilmstripViewerContainer({ images }) {
       isOpen={isOpen}
       rearrangePages={store.transcriptions.rearrangePages}
       selectImage={selectImage}
-      setSlopeKeys={store.transcriptions.setSlopeKeys}
       setOpen={setOpen}
       slopeDefinitions={store.transcriptions.slopeDefinitions}
       slopeKeys={store.transcriptions.slopeKeys}

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -21,6 +21,7 @@ function FilmstripViewerContainer({ images }) {
       isOpen={isOpen}
       rearrangePages={store.transcriptions.rearrangePages}
       selectImage={selectImage}
+      setSlopeKeys={store.transcriptions.setSlopeKeys}
       setOpen={setOpen}
       slopeDefinitions={store.transcriptions.slopeDefinitions}
       slopeKeys={store.transcriptions.slopeKeys}

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -7,10 +7,10 @@ function FilmstripViewerContainer({ images }) {
   const [isOpen, setOpen] = React.useState(true)
   const store = React.useContext(AppContext)
   const disabled = store.aggregations.showModal || store.transcriptions.isActive
-  const selectImage = (id) => {
+  const selectImage = (page) => {
     store.image.reset()
     store.transcriptions.setActiveTranscription()
-    store.transcriptions.changeIndex(id)
+    store.transcriptions.changeIndex(page)
   }
 
   return  (
@@ -20,6 +20,7 @@ function FilmstripViewerContainer({ images }) {
       isOpen={isOpen}
       selectImage={selectImage}
       setOpen={setOpen}
+      slopeKeys={store.transcriptions.slopeKeys}
       subjectIndex={store.transcriptions.index}
     />
   )

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -7,14 +7,15 @@ function FilmstripViewerContainer({ images }) {
   const [isOpen, setOpen] = React.useState(true)
   const store = React.useContext(AppContext)
   const disabled = store.aggregations.showModal || store.transcriptions.isActive
-  const selectImage = (page) => {
+  const selectImage = (page, slopeIndex) => {
     store.image.reset()
     store.transcriptions.setActiveTranscription()
-    store.transcriptions.changeIndex(page)
+    store.transcriptions.changeIndex(page, slopeIndex)
   }
 
   return  (
     <FilmstripViewer
+      activeSlope={store.transcriptions.slopeIndex}
       disabled={disabled}
       images={images}
       isOpen={isOpen}

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -19,6 +19,7 @@ function FilmstripViewerContainer({ images }) {
       disabled={disabled}
       images={images}
       isOpen={isOpen}
+      rearrangePages={store.transcriptions.rearrangePages}
       selectImage={selectImage}
       setOpen={setOpen}
       slopeDefinitions={store.transcriptions.slopeDefinitions}

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -21,6 +21,7 @@ function FilmstripViewerContainer({ images }) {
       isOpen={isOpen}
       selectImage={selectImage}
       setOpen={setOpen}
+      slopeDefinitions={store.transcriptions.slopeDefinitions}
       slopeKeys={store.transcriptions.slopeKeys}
       subjectIndex={store.transcriptions.index}
     />

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -9,13 +9,13 @@ export default function FilmstripThumbnail ({
   index,
   isActive,
   page,
+  rearrangePages,
   rotationDegrees,
   selectImage,
   setHoveredIndex,
   setSlopeValues,
   slopeDefinition,
   slopeIndex,
-  slopeKey,
   slopeValues,
   src
 }) {
@@ -43,7 +43,10 @@ export default function FilmstripThumbnail ({
         onBlur={() => onHover(false)}
         onClick={() => selectImage(page, slopeIndex)}
         onFocus={() => onHover(true)}
-        onDragEnd={() => setHoveredIndex(null)}
+        onDragEnd={() => {
+          setHoveredIndex(null)
+          rearrangePages()
+        }}
         onDragOver={(e) => stopEvents(e)}
         onDragEnter={(e) => handleDragEnter(e, index, hoveredIndex, setHoveredIndex, slopeValues, setSlopeValues)}
         onDragStart={() => setHoveredIndex(index)}

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -47,8 +47,8 @@ export default function FilmstripThumbnail ({
           setHoveredIndex(null)
           rearrangePages()
         }}
-        onDragOver={(e) => stopEvents(e)}
         onDragEnter={(e) => handleDragEnter(e, index, hoveredIndex, setHoveredIndex, slopeValues, setSlopeValues)}
+        onDragOver={(e) => stopEvents(e)}
         onDragStart={() => setHoveredIndex(index)}
         onMouseEnter={() => onHover(true)}
         onMouseLeave={() => onHover(false)}

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -3,26 +3,60 @@ import { Box, Button, Image } from 'grommet'
 import { bool, func, number, string } from 'prop-types'
 import ThumbnailBorder from './ThumbnailBorder'
 
-export default function FilmstripThumbnail ({ disabled, index, isActive, rotationDegrees, selectImage, src }) {
+export default function FilmstripThumbnail ({
+  disabled,
+  hoveredIndex,
+  index,
+  isActive,
+  page,
+  rotationDegrees,
+  selectImage,
+  setHoveredIndex,
+  setSlopeValues,
+  slopeKey,
+  slopeValues,
+  src
+}) {
   const [isHover, onHover] = React.useState(false)
+
+  function handleDragEnter(e, dragIndex, hoveredIndex, setHoveredIndex, slopes, rearrangeSlopes) {
+    e.preventDefault()
+    let copiedArray = slopes.slice()
+    const itemToMove = copiedArray.splice(hoveredIndex, 1)[0]
+    copiedArray.splice(dragIndex,0,itemToMove)
+    setHoveredIndex(dragIndex)
+    rearrangeSlopes(copiedArray)
+  }
+
+  function stopEvents(e) {
+    e.preventDefault()
+    e.stopPropagation()
+  }
 
   return (
       <Button
         disabled={disabled}
+        draggable
         margin='xsmall'
         onBlur={() => onHover(false)}
-        onClick={() => selectImage(index)}
+        onClick={() => selectImage(page)}
         onFocus={() => onHover(true)}
+        onDragEnd={() => setHoveredIndex(null)}
+        onDragOver={(e) => stopEvents(e)}
+        onDragEnter={(e) => handleDragEnter(e, index, hoveredIndex, setHoveredIndex, slopeValues, setSlopeValues)}
+        onDragStart={() => setHoveredIndex(index)}
         onMouseEnter={() => onHover(true)}
         onMouseLeave={() => onHover(false)}
       >
         <Box height='xsmall' width='xsmall'>
-          <ThumbnailBorder
-            isActive={isActive}
-            isHover={isHover}
-            rotationDegrees={rotationDegrees}
-          />
-          <Image alt={`Subject Page ${index + 1}`} fit='cover' src={src} />
+          {isActive && (
+            <ThumbnailBorder
+              isActive={isActive}
+              isHover={isHover}
+              rotationDegrees={rotationDegrees}
+            />
+          )}
+          <Image alt={`Subject Page ${page + 1}`} fit='cover' src={src} />
         </Box>
       </Button>
   )

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -13,6 +13,7 @@ export default function FilmstripThumbnail ({
   selectImage,
   setHoveredIndex,
   setSlopeValues,
+  slopeDefinition,
   slopeIndex,
   slopeKey,
   slopeValues,
@@ -50,13 +51,11 @@ export default function FilmstripThumbnail ({
         onMouseLeave={() => onHover(false)}
       >
         <Box height='xsmall' width='xsmall'>
-          {isActive && (
-            <ThumbnailBorder
-              isActive={isActive}
-              isHover={isHover}
-              rotationDegrees={rotationDegrees}
-            />
-          )}
+          <ThumbnailBorder
+            isActive={isActive}
+            isHover={isHover}
+            rotationDegrees={slopeDefinition}
+          />
           <Image alt={`Subject Page ${page + 1}`} fit='cover' src={src} />
         </Box>
       </Button>

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -13,6 +13,7 @@ export default function FilmstripThumbnail ({
   selectImage,
   setHoveredIndex,
   setSlopeValues,
+  slopeIndex,
   slopeKey,
   slopeValues,
   src
@@ -39,7 +40,7 @@ export default function FilmstripThumbnail ({
         draggable
         margin='xsmall'
         onBlur={() => onHover(false)}
-        onClick={() => selectImage(page)}
+        onClick={() => selectImage(page, slopeIndex)}
         onFocus={() => onHover(true)}
         onDragEnd={() => setHoveredIndex(null)}
         onDragOver={(e) => stopEvents(e)}

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
@@ -3,8 +3,17 @@ import React from 'react'
 import { Button } from 'grommet'
 import FilmstripThumbnail from './FilmstripThumbnail'
 
+const preventDefaultSpy = jest.fn()
+const rearrangePagesSpy = jest.fn()
+const setHoveredIndexSpy = jest.fn()
+const setSlopeValues = jest.fn()
 const selectImage = jest.fn()
 const setStateSpy = jest.fn()
+const slopeValues = ['frame0', 'frame1', 'frame2']
+const stopPropagationSpy = jest.fn()
+const mockEvent = { preventDefault: preventDefaultSpy, stopPropagation: stopPropagationSpy }
+
+let button
 let wrapper
 
 describe('Component > FilmstripViewer', function () {
@@ -14,9 +23,14 @@ describe('Component > FilmstripViewer', function () {
       .mockImplementation((init) => [init, setStateSpy])
     wrapper = shallow(
       <FilmstripThumbnail
+        rearrangePages={rearrangePagesSpy}
+        setSlopeValues={setSlopeValues}
+        slopeValues={slopeValues}
+        setHoveredIndex={setHoveredIndexSpy}
         selectImage={selectImage}
         src={'www.testlocation.com'}
       />)
+      button = wrapper.find(Button).first()
   })
 
   afterEach(() => jest.clearAllMocks());
@@ -26,32 +40,50 @@ describe('Component > FilmstripViewer', function () {
   })
 
   it('calls the selectImage prop on click', function() {
-    const button = wrapper.find(Button).first()
     button.simulate('click')
     expect(selectImage).toHaveBeenCalled()
   })
 
   it('changes the isHover state on blur', function() {
-    const button = wrapper.find(Button).first()
     button.simulate('blur')
     expect(setStateSpy).toHaveBeenCalledWith(false)
   })
 
   it('changes the isHover state on mouse leave', function() {
-    const button = wrapper.find(Button).first()
     button.simulate('mouseleave')
     expect(setStateSpy).toHaveBeenCalledWith(false)
   })
 
   it('changes the isHover state on mouse enter', function() {
-    const button = wrapper.find(Button).first()
     button.simulate('mouseenter')
     expect(setStateSpy).toHaveBeenCalledWith(true)
   })
 
   it('changes the isHover state on focus', function() {
-    const button = wrapper.find(Button).first()
     button.simulate('focus')
     expect(setStateSpy).toHaveBeenCalledWith(true)
+  })
+
+  it('should perform a drag end', function () {
+    button.simulate('dragend')
+    expect(setHoveredIndexSpy).toHaveBeenCalledWith(null)
+    expect(rearrangePagesSpy).toHaveBeenCalled()
+  })
+
+  it('should perform a drag enter', function () {
+    button.simulate('dragenter', mockEvent)
+    expect(setHoveredIndexSpy).toHaveBeenCalledWith(0)
+    expect(setSlopeValues).toHaveBeenCalled()
+  })
+
+  it('should perform a drag over', function () {
+    button.simulate('dragover', mockEvent)
+    expect(preventDefaultSpy).toHaveBeenCalled()
+    expect(stopPropagationSpy).toHaveBeenCalled()
+  })
+
+  it('should perform a drag start', function () {
+    button.simulate('dragstart')
+    expect(setHoveredIndexSpy).toHaveBeenCalledWith(0)
   })
 })

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/ThumbnailBorder.js
@@ -8,7 +8,10 @@ export const StyledBox = styled(Box)`
   position: absolute;
 `
 
+const INTERVAL = 10
+
 export default function ThumbnailBorder({ isActive, isHover, rotationDegrees }) {
+  const roundedSlope = INTERVAL * Math.round(rotationDegrees/INTERVAL) || null
   let border = {}
   if (isHover) {
     border = { color: 'brand', size: 'medium' }
@@ -24,12 +27,12 @@ export default function ThumbnailBorder({ isActive, isHover, rotationDegrees }) 
       height='xsmall'
       justify='center'
       width='xsmall'>
-      {rotationDegrees && (
+      {roundedSlope && (
         <Text
           color='white'
           size='xlarge'
         >
-          {rotationDegrees}&deg;
+          {roundedSlope}&deg;
         </Text>
       )}
     </StyledBox>

--- a/src/components/LineViewer/LineViewerContainer.js
+++ b/src/components/LineViewer/LineViewerContainer.js
@@ -31,9 +31,7 @@ function LineViewerContainer({ isLoaded }) {
   }))
 
   const transcriptionIndex = store.transcriptions.activeTranscriptionIndex
-  const reduction = store.transcriptions.current &&
-    store.transcriptions.current.text &&
-    store.transcriptions.current.text.get(`frame${store.transcriptions.index}`)[transcriptionIndex]
+  const reduction = store.transcriptions.currentTranscriptions[transcriptionIndex]
   const consensusText = reduction && (reduction.edited_consensus_text || reduction.consensus_text)
   const typedChoice = localStore.transcriptionOptions.length + 1
 

--- a/src/components/LineViewer/LineViewerContainer.js
+++ b/src/components/LineViewer/LineViewerContainer.js
@@ -5,7 +5,7 @@ import { bool } from 'prop-types'
 import LineViewer from './LineViewer'
 
 function LineViewerContainer({ isLoaded }) {
-  const store = React.useContext(AppContext) || {}
+  const store = React.useContext(AppContext)
 
   const localStore = useLocalStore(() => ({
     isLoaded,

--- a/src/components/LineViewer/LineViewerContainer.js
+++ b/src/components/LineViewer/LineViewerContainer.js
@@ -5,7 +5,7 @@ import { bool } from 'prop-types'
 import LineViewer from './LineViewer'
 
 function LineViewerContainer({ isLoaded }) {
-  const store = React.useContext(AppContext)
+  const store = React.useContext(AppContext) || {}
 
   const localStore = useLocalStore(() => ({
     isLoaded,

--- a/src/components/LineViewer/LineViewerContainer.spec.js
+++ b/src/components/LineViewer/LineViewerContainer.spec.js
@@ -8,19 +8,18 @@ let wrapper
 
 const deleteCurrentLineSpy = jest.fn()
 const setActiveTranscriptionSpy = jest.fn()
+const currentFrame = {
+  consensus_score: 0,
+  consensus_text: 'This text',
+  clusters_text: [
+    ['This, That'],
+    ['text, text']
+  ],
+  gold_standard: [false, false]
+}
 const currentTranscription = {
   text: new Map([
-    ['frame0', [
-      {
-        consensus_score: 0,
-        consensus_text: 'This text',
-        clusters_text: [
-          ['This, That'],
-          ['text, text']
-        ],
-        gold_standard: [false, false]
-      }
-    ]]
+    ['frame0', [currentFrame]]
   ])
 }
 
@@ -30,6 +29,7 @@ const contextValues = {
   },
   transcriptions: {
     activeTranscriptionIndex: 0,
+    currentTranscriptions: currentFrame,
     deleteCurrentLine: deleteCurrentLineSpy,
     current: currentTranscription,
     index: 0,
@@ -41,6 +41,9 @@ const contextValues = {
 
 describe('Component > LineViewerContainer', function () {
   it('should render without crashing', function () {
+    jest
+      .spyOn(React, 'useContext')
+      .mockImplementation(() => contextValues )
     wrapper = shallow(<LineViewerContainer />);
     expect(wrapper).toBeDefined()
   })

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPane.js
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react'
 import SVGLines from './SVGLines'
 
 function AnnotationsPane({
+  activeSlope,
   activeTranscriptionIndex,
   extractLines,
   isApproved,
@@ -21,6 +22,7 @@ function AnnotationsPane({
     <g transform={offset}>
       {extractLines.map((lines, i) => (
         <SVGLines
+          activeSlope={activeSlope}
           activeTranscriptionIndex={activeTranscriptionIndex}
           key={`SVG_LINE_${i}`}
           isExtract
@@ -30,6 +32,7 @@ function AnnotationsPane({
       ))}
       {reductionLines.map((lines, i) => (
         <SVGLines
+          activeSlope={activeSlope}
           activeTranscriptionIndex={activeTranscriptionIndex}
           key={`SVG_LINE_${i}`}
           isApproved={isApproved}

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
@@ -19,14 +19,14 @@ function AnnotationsPaneContainer({ x, y }) {
 
   return (
     <AnnotationsPane
-      x={x}
-      y={y}
       activeSlope={store.transcriptions.activeSlope}
       activeTranscriptionIndex={store.transcriptions.activeTranscriptionIndex}
       isApproved={store.transcriptions.approved}
       linesVisible={store.editor.linesVisible}
       onLineClick={onLineClick}
       reductionLines={reductionLines}
+      x={x}
+      y={y}
     />
   )
 }

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
@@ -21,8 +21,8 @@ function AnnotationsPaneContainer({ x, y }) {
     <AnnotationsPane
       x={x}
       y={y}
+      activeSlope={store.transcriptions.activeSlope}
       activeTranscriptionIndex={store.transcriptions.activeTranscriptionIndex}
-      extractLines={store.transcriptions.parsedExtracts}
       isApproved={store.transcriptions.approved}
       linesVisible={store.editor.linesVisible}
       onLineClick={onLineClick}

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
@@ -7,12 +7,10 @@ import { constructCoordinates } from 'helpers/parseTranscriptionData'
 function AnnotationsPaneContainer({ x, y }) {
   let reductionLines = []
   const store = React.useContext(AppContext)
-  const index = store.transcriptions.index
-  const transcription = store.transcriptions.current
-  const transcriptionFrame = transcription && transcription.text && transcription.text.get(`frame${index}`)
+  const transcriptions = store.transcriptions.currentTranscriptions
 
-  if (transcriptionFrame) {
-    reductionLines = transcriptionFrame.map(transcription => constructCoordinates(transcription))
+  if (transcriptions) {
+    reductionLines = transcriptions.map(transcription => constructCoordinates(transcription))
   }
 
   const onLineClick = (index) => store.transcriptions.setActiveTranscription(index)

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.spec.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.spec.js
@@ -12,15 +12,12 @@ const contextValues = {
     linesVisible: true
   },
   transcriptions: {
+    activeSlope: 0,
     approved: false,
-    current: {
-      text: new Map([
-        [ 'frame0', [{
-          clusters_x: [],
-          clusters_y: []
-        }] ]
-      ])
-    },
+    currentTranscriptions: [{
+      clusters_x: [],
+      clusters_y: []
+    }],
     index: 0,
     extracts: [extract]
   }

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
@@ -7,7 +7,15 @@ export const G = styled('g')`
   ${css`cursor: ${props => props.clickable && !props.isApproved ? 'pointer' : 'inherit'};`}
 `
 
-export default function SVGLines({ activeTranscriptionIndex, isApproved, lines, onLineClick, isExtract, reductionIndex }) {
+export default function SVGLines({
+  activeSlope,
+  activeTranscriptionIndex,
+  isApproved,
+  lines,
+  onLineClick,
+  isExtract,
+  reductionIndex
+}) {
   const circleWidth = isExtract ? 4 : 10
   const dashArray = isExtract ? '4' : '0'
   const strokeWidth = isExtract ? '0.5' : '3'
@@ -20,6 +28,7 @@ export default function SVGLines({ activeTranscriptionIndex, isApproved, lines, 
       if (!isApproved) onLineClick()
     }}>
       {lines.map((line, index) => {
+        if (activeSlope !== line.slope) return null
         const color = isExtract && isActive ? indexToColor(index) : indexToColor(reductionIndex)
         const svgPoints = []
         const isLeftToRight = line.x1 < line.x2

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.js
@@ -85,6 +85,7 @@ export default function SVGLines({
 }
 
 SVGLines.propTypes = {
+  activeSlope: number,
   isApproved: bool,
   isExtract: bool,
   lines: array,
@@ -93,6 +94,7 @@ SVGLines.propTypes = {
 }
 
 SVGLines.defaultProps = {
+  activeSlope: 0,
   isApproved: false,
   isExtract: false,
   lines: [],

--- a/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.spec.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/SVGLines.spec.js
@@ -7,16 +7,19 @@ import SVGLines, { G } from './SVGLines'
 let wrapper
 
 const lines = [
-  { x1: 0, x2: 0, y1: 100, y2: 100 }
+  { x1: 0, x2: 0, y1: 100, y2: 100, slope: 0 },
+  { x1: 0, x2: 0, y1: 200, y2: 200, slope: 0 },
+  { x1: 0, x2: 0, y1: 300, y2: 300, slope: 90 },
+  { x1: 0, x2: 0, y1: 400, y2: 400, slope: 90 }
 ]
 
 const rightToLeftLines = [
-  { x1: 0, x2: 100, y1: 100, y2: 100 }
+  { x1: 0, x2: 100, y1: 100, y2: 100, slope: 0 }
 ]
 
 describe('Component > SVGLines', function () {
   beforeEach(function() {
-    wrapper = shallow(<SVGLines lines={lines} />);
+    wrapper = shallow(<SVGLines activeSlope={90} lines={lines} />);
   })
 
   it('should render without crashing', function () {
@@ -26,6 +29,11 @@ describe('Component > SVGLines', function () {
   it('should render clickable lines', function () {
     const tree = renderer.create(wrapper).toJSON()
     expect(tree).toHaveStyleRule('cursor', 'pointer')
+  })
+
+  it('only displays lines that match the activeSlope', function () {
+    const lines = wrapper.find('g')
+    expect(lines.length).toBe(2)
   })
 
   describe('extract line right to left', function () {

--- a/src/helpers/isEqual.js
+++ b/src/helpers/isEqual.js
@@ -1,0 +1,9 @@
+export default function isEqual(a, b) {
+  if (a instanceof Array && b instanceof Array) {
+    if (a.length !== b.length)
+      return false
+
+    return a.every((val, i) => val === b[i])
+  }
+  return a === b
+}

--- a/src/helpers/isEqual.spec.js
+++ b/src/helpers/isEqual.spec.js
@@ -1,0 +1,29 @@
+import isEqual from './isEqual'
+
+describe('Helper > isEqual', function () {
+  describe('when passed arrays', function () {
+    it('should check if equal', function () {
+      expect(isEqual(['foo', 'bar'], ['foo', 'bar'])).toBe(true)
+    })
+
+    it('should check if unequal', function () {
+      expect(isEqual(['foo', 'bar'], ['bar', 'foo'])).toBe(false)
+    })
+
+    describe('when of unequal lengths', function () {
+      it('should return false', function () {
+        expect(isEqual(['foo', 'bar'], ['foo'])).toBe(false)
+      })
+    })
+  })
+
+  describe('when passed other variables', function () {
+    it('should check if equal', function () {
+      expect(isEqual('foo', 'foo')).toBe(true)
+    })
+
+    it('should check if unequal', function () {
+      expect(isEqual('foo', 'bar')).toBe(false)
+    })
+  })
+})

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -9,7 +9,8 @@ function constructCoordinates(line) {
       x1: line.clusters_x[0],
       x2: line.clusters_x[lastPoint],
       y1: line.clusters_y[0],
-      y2: line.clusters_y[lastPoint]
+      y2: line.clusters_y[lastPoint],
+      slope: line.line_slope
     })
   }
   return points;
@@ -65,7 +66,7 @@ function mapExtractsToReductions(
           time.setUTCSeconds(classification.time)
           result.push({
             goldStandard: reduction.gold_standard[idIndex],
-            slope: classification[currentFrame].slope[extractIndex],
+            slope: reduction.line_slope,
             text: text[0],
             time,
             user: extractUsers[userId],

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -30,22 +30,24 @@ export function spotInGroup(slopes, index) {
   return BORDER_MAP.NONE
 }
 
-export default function getSlopeGroups(slopeKeys) {
-  const slopeGroups = []
-  const example = ['frame0.0', 'frame0.1', 'frame1.0', 'frame2.0', 'frame2.1']
-
+export function isolateGroups(slopeKeys) {
   let currentPage;
-  let frameGroup;
+  let frameGroup = [];
+  let slopeGroups = []
 
-  example.forEach(key => {
+  slopeKeys.forEach((key, index) => {
     const keyPage = getPage(key)
-
     if (keyPage !== currentPage) {
+      if (frameGroup.length > 0) {
+        slopeGroups.push(frameGroup)
+      }
       frameGroup = []
       currentPage = keyPage
-      frameGroup.push(key)
     }
-
     frameGroup.push(key)
+    if (!slopeKeys[index + 1]) {
+      slopeGroups.push(frameGroup)
+    }
   })
+  return slopeGroups
 }

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -17,8 +17,8 @@ export function getSlopeLabel(key) {
 export function spotInGroup(slopes, index) {
   const currentPage = getPage(slopes[index])
 
-  const samePageToLeft = slopes[index - 1] && getPage(slopes[index - 1]) === currentPage
-  const samePageToRight = slopes[index + 1] && getPage(slopes[index + 1]) === currentPage
+  const samePageToLeft = index - 1 >= 0 && getPage(slopes[index - 1]) === currentPage
+  const samePageToRight = index + 1 < slopes.length && getPage(slopes[index + 1]) === currentPage
 
   if (!samePageToLeft && samePageToRight) {
     return BORDER_MAP.LEFT

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -1,3 +1,10 @@
+const BORDER_MAP = {
+  LEFT: [{ side: 'left'}, {side: 'horizontal' }],
+  MIDDLE: [{ side: 'horizontal' }],
+  RIGHT: [{ side: 'right'}, {side: 'horizontal' }],
+  NONE: false
+}
+
 export function getPage(key) {
   const dotIndex = key.indexOf('.')
   return parseInt(key[dotIndex -1])
@@ -5,6 +12,22 @@ export function getPage(key) {
 
 export function getSlopeLabel(key) {
   return parseInt(key[key.length - 1])
+}
+
+export function spotInGroup(slopes, index) {
+  const currentPage = getPage(slopes[index])
+
+  const samePageToLeft = slopes[index - 1] && getPage(slopes[index - 1]) === currentPage
+  const samePageToRight = slopes[index + 1] && getPage(slopes[index + 1]) === currentPage
+
+  if (!samePageToLeft && samePageToRight) {
+    return BORDER_MAP.LEFT
+  } else if (samePageToLeft && samePageToRight) {
+    return BORDER_MAP.MIDDLE
+  } else if (samePageToLeft && !samePageToRight) {
+    return BORDER_MAP.RIGHT
+  }
+  return BORDER_MAP.NONE
 }
 
 export default function getSlopeGroups(slopeKeys) {

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -1,4 +1,4 @@
-const BORDER_MAP = {
+export const BORDER_MAP = {
   LEFT: [{ side: 'left'}, {side: 'horizontal' }],
   MIDDLE: [{ side: 'horizontal' }],
   RIGHT: [{ side: 'right'}, {side: 'horizontal' }],
@@ -7,10 +7,12 @@ const BORDER_MAP = {
 
 export function getPage(key) {
   const dotIndex = key.indexOf('.')
-  return parseInt(key[dotIndex -1])
+  if (dotIndex === -1) return 0
+  return parseInt(key[dotIndex - 1])
 }
 
 export function getSlopeLabel(key) {
+  if (!key || key.length === 0) return 0
   return parseInt(key[key.length - 1])
 }
 

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -45,7 +45,7 @@ export function isolateGroups(slopeKeys) {
       currentPage = keyPage
     }
     frameGroup.push(key)
-    if (!slopeKeys[index + 1]) {
+    if (index === slopeKeys.length - 1) {
       slopeGroups.push(frameGroup)
     }
   })

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -1,0 +1,28 @@
+export function getPage(key) {
+  const dotIndex = key.indexOf('.')
+  return key[dotIndex -1]
+}
+
+function getSlopeLabel(key) {
+  return key[key.length - 1]
+}
+
+export default function getSlopeGroups(slopeKeys) {
+  const slopeGroups = []
+  const example = ['frame0.0', 'frame0.1', 'frame1.0', 'frame2.0', 'frame2.1']
+
+  let currentPage;
+  let frameGroup;
+
+  example.forEach(key => {
+    const keyPage = getPage(key)
+
+    if (keyPage !== currentPage) {
+      frameGroup = []
+      currentPage = keyPage
+      frameGroup.push(key)
+    }
+
+    frameGroup.push(key)
+  })
+}

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -1,10 +1,10 @@
 export function getPage(key) {
   const dotIndex = key.indexOf('.')
-  return key[dotIndex -1]
+  return parseInt(key[dotIndex -1])
 }
 
-function getSlopeLabel(key) {
-  return key[key.length - 1]
+export function getSlopeLabel(key) {
+  return parseInt(key[key.length - 1])
 }
 
 export default function getSlopeGroups(slopeKeys) {

--- a/src/helpers/slopeHelpers.spec.js
+++ b/src/helpers/slopeHelpers.spec.js
@@ -1,0 +1,80 @@
+import {
+  BORDER_MAP,
+  getPage,
+  getSlopeLabel,
+  isolateGroups,
+  spotInGroup
+} from './slopeHelpers'
+
+describe('Helper > getPage', function () {
+  it('should default to 0', function () {
+    expect(getPage('frame0')).toBe(0)
+  })
+
+  it('should return the page number', function () {
+    expect(getPage('frame1.0')).toBe(1)
+  })
+})
+
+describe('Helper > getSlopeLabel', function () {
+  it('should default to 0', function () {
+    expect(getSlopeLabel()).toBe(0)
+    expect(getSlopeLabel('')).toBe(0)
+  })
+
+  it('should return the page number', function () {
+    expect(getSlopeLabel('frame1.1')).toBe(1)
+  })
+})
+
+describe('Helper > isolateGroups', function () {
+  it('should not isolate groups when non existent', function () {
+    const keys = ['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0']
+    const groups = [['frame0.0'], ['frame1.0'], ['frame2.0'], ['frame3.0']]
+    expect(isolateGroups(keys)).toEqual(groups)
+  })
+
+  it('should isolate intermittent groups', function () {
+    const keys = ['frame0.0', 'frame1.0', 'frame1.1', 'frame2.0', 'frame3.0', 'frame3.1', 'frame4.0']
+    const groups = [['frame0.0'], ['frame1.0', 'frame1.1'], ['frame2.0'], ['frame3.0', 'frame3.1'], ['frame4.0']]
+    expect(isolateGroups(keys)).toEqual(groups)
+  })
+
+  it('should isolate consecutive groups', function () {
+    const keys = ['frame0.0', 'frame1.0', 'frame1.1', 'frame2.0', 'frame2.1', 'frame3.0']
+    const groups = [['frame0.0'], ['frame1.0', 'frame1.1'], ['frame2.0', 'frame2.1'], ['frame3.0']]
+    expect(isolateGroups(keys)).toEqual(groups)
+  })
+
+  it('should isolate groups at the end', function () {
+    const keys = ['frame0.0', 'frame1.0', 'frame1.1']
+    const groups = [['frame0.0'], ['frame1.0', 'frame1.1']]
+    expect(isolateGroups(keys)).toEqual(groups)
+  })
+
+  it('should isolate groups at the beginning', function () {
+    const keys = ['frame0.0', 'frame0.1', 'frame1.0', 'frame2.0']
+    const groups = [['frame0.0', 'frame0.1'], ['frame1.0'], ['frame2.0']]
+    expect(isolateGroups(keys)).toEqual(groups)
+  })
+})
+
+describe('Helper > spotInGroup', function () {
+  const slopes = ['frame0.0', 'frame1.0', 'frame1.1', 'frame1.2']
+
+  it('should apply a border at the beginning of a group', function () {
+    expect(spotInGroup(slopes, 0)).toBe(BORDER_MAP.NONE)
+  })
+
+  it('should apply a border at the middle of a group', function () {
+    expect(spotInGroup(slopes, 1)).toBe(BORDER_MAP.LEFT)
+  })
+
+  it('should apply a border at the end of a group', function () {
+    expect(spotInGroup(slopes, 2)).toBe(BORDER_MAP.MIDDLE)
+  })
+
+  it('should not apply a border if not in a group', function () {
+    expect(spotInGroup(slopes, 3)).toBe(BORDER_MAP.RIGHT)
+  })
+})

--- a/src/screens/Editor/Editor.spec.js
+++ b/src/screens/Editor/Editor.spec.js
@@ -66,6 +66,7 @@ const contextValues = {
     index: 0,
     lockedByCurrentUser: false,
     setActiveTranscription: setActiveTranscriptionSpy,
+    slopeKeys: [],
     unlockTranscription: unlockTranscriptionSpy
   }
 }

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -79,6 +79,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   function changeIndex(index) {
     self.index = index
+    self.setParsedExtracts()
   }
 
   function checkForFlagUpdate() {
@@ -224,7 +225,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
         }
       })
     })
-    self.slopeValues = allSlopeKeys
+    self.slopeKeys = allSlopeKeys
   }
 
   const getTranscriberInfo = flow(function * getTranscriberInfo(arrangedExtractsByUser) {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -14,7 +14,6 @@ import Reduction from './Reduction'
 
 let Frame = types.array(Reduction)
 const Extension = types.refinement(types.map(Frame), snapshot => {
-  console.log(snapshot);
   return Ramda.all(Ramda.startsWith('frame'), Ramda.keys(snapshot))
 })
 
@@ -510,6 +509,12 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   get isActive () {
     return self.activeTranscriptionIndex !== undefined
+  },
+
+  get currentTranscriptions () {
+    return self.current && self.current.text &&
+      (self.current.text.get(`frame${self.index}.${self.slopeIndex}`) ||
+       self.current.text.get(`frame${self.index}`))
   },
 
   get readyForReview () {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -165,12 +165,14 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
         textObject[key] = reduction[key]
       }
     })
+    self.current.frame_order = []
     self.current.low_consensus_lines = reduction.low_consensus_lines
     self.current.parameters = reduction.parameters
     self.current.reducer = reduction.reducer
     self.current.text = textObject
     self.current.transcribed_lines = reduction.transcribed_lines
     self.saveTranscription()
+    self.getSlopeKeys()
   }
 
   const fetchExtracts = flow(function * fetchExtracts(id) {
@@ -409,6 +411,10 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     self.parsedExtracts = extracts
   }
 
+  function setSlopeKeys(keys) {
+    self.slopeKeys = keys
+  }
+
   function setTextObject(text) {
     self.current.text.set(`frame${self.index}`, text)
     self.setParsedExtracts()
@@ -485,6 +491,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     selectTranscription,
     setActiveTranscription,
     setParsedExtracts: (extractsByUser) => undoManager.withoutUndo(() => setParsedExtracts(extractsByUser)),
+    setSlopeKeys,
     setTextObject,
     setTranscription: (transcription) => undoManager.withoutUndo(() => setTranscription(transcription)),
     toggleError: () => undoManager.withoutUndo(() => toggleError()),

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -165,7 +165,12 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
         textObject[key] = reduction[key]
       }
     })
+    self.current.text.forEach((value, key) => {
+      if (!textObject[key]) detach(value)
+    })
     self.current.frame_order = []
+    self.index = 0
+    self.slopeIndex = 0
     self.current.low_consensus_lines = reduction.low_consensus_lines
     self.current.parameters = reduction.parameters
     self.current.reducer = reduction.reducer

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -522,9 +522,10 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   },
 
   get currentTranscriptions () {
-    return self.current && self.current.text &&
+    const current = self.current && self.current.text &&
       (self.current.text.get(`frame${self.index}.${self.slopeIndex}`) ||
        self.current.text.get(`frame${self.index}`))
+    return current || []
   },
 
   get readyForReview () {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -44,6 +44,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   extractUsers: types.optional(types.frozen()),
   page: types.optional(types.number, 0),
   showSaveTranscriptionError: types.optional(types.boolean, false),
+  slopeIndex: types.optional(types.number, 0),
   slopeKeys: types.array(types.string),
   totalPages: types.optional(types.number, 1),
   rawExtracts: types.array(types.frozen()),
@@ -77,8 +78,9 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     self.setParsedExtracts()
   }
 
-  function changeIndex(index) {
+  function changeIndex(index, slopeIndex) {
     self.index = index
+    self.slopeIndex = slopeIndex
     self.setParsedExtracts()
   }
 
@@ -273,6 +275,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     self.getSlopeKeys()
     self.current = undefined
     self.index = 0
+    self.slopeIndex = 0
     self.all.clear()
   }
 

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -229,7 +229,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     frames.forEach(key => {
       const frame = self.current.text.get(key)
       frame.forEach(r => {
-        const slopeKey = `${key}.${r.slope_label}`
+        const slopeKey = key.includes('.') ? key : `${key}.${r.slope_label}`
         if (!allSlopeKeys.includes(slopeKey)) {
           allSlopeKeys.push(slopeKey)
         }
@@ -345,6 +345,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   const saveTranscription = flow(function * saveTranscription() {
     undoManager.withoutUndo(() => self.asyncState = ASYNC_STATES.LOADING)
+    const frame_order = toJS(self.current.frame_order)
     const textBlob = toJS(self.current.text)
     const additionalData = {
       low_consensus_lines: self.current.low_consensus_lines,
@@ -356,6 +357,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
         type: 'transcriptions',
         attributes: {
           flagged: self.current.flagged,
+          frame_order,
           text: updatedTranscription
         }
       }

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -20,6 +20,7 @@ const Extension = types.refinement(types.map(Frame), snapshot => {
 const Transcription = types.model('Transcription', {
   id: types.identifier,
   flagged: types.optional(types.boolean, false),
+  frame_order: types.array(types.string),
   group_id: types.optional(types.string, ''),
   internal_id: types.optional(types.string, ''),
   last_modified: types.optional(types.string, ''),
@@ -114,6 +115,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     return Transcription.create({
       id: transcription.id,
       flagged: transcription.attributes.flagged,
+      frame_order: transcription.attributes.frame_order,
       group_id: transcription.attributes.group_id,
       last_modified,
       internal_id: transcription.attributes.internal_id || '',
@@ -222,7 +224,10 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const allSlopeKeys = []
     const slopeDefinitions = {}
 
-    self.current.text.forEach((frame, key) => {
+    let frames = self.current.frame_order.length ? self.current.frame_order : Array.from(self.current.text.keys())
+
+    frames.forEach(key => {
+      const frame = self.current.text.get(key)
       frame.forEach(r => {
         const slopeKey = `${key}.${r.slope_label}`
         if (!allSlopeKeys.includes(slopeKey)) {
@@ -233,6 +238,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
         }
       })
     })
+
     self.slopeKeys = allSlopeKeys
     self.slopeDefinitions = slopeDefinitions
   }
@@ -302,7 +308,9 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
         })
       })
     })
+    self.current.frame_order = Object.keys(rearrangedText)
     self.current.text = rearrangedText
+    self.saveTranscription()
   }
 
   function reset() {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -453,6 +453,11 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     updateApproval: (isChecked) => undoManager.withoutUndo(() => updateApproval(isChecked))
   }
 }).views(self => ({
+  get activeSlope () {
+    const activeSlopeKey = `frame${self.index}.${self.slopeIndex}`
+    return self.slopeDefinitions[activeSlopeKey]
+  },
+
   get approved () {
     return !!(self.current && self.current.status === 'approved')
   },

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -7,6 +7,7 @@ import { reaction, toJS } from 'mobx'
 import { request } from 'graphql-request'
 import { config } from 'config'
 import { constructText, mapExtractsToReductions } from 'helpers/parseTranscriptionData'
+import { getPage, getSlopeLabel, isolateGroups } from 'helpers/slopeHelpers'
 import getError, { TranscriptionError } from 'helpers/getError'
 import MODALS from 'helpers/modals'
 import Reduction from './Reduction'
@@ -276,6 +277,21 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     })
   })
 
+  function rearrangePages(keys) {
+    const groupedKeys = isolateGroups(keys)
+    console.log(groupedKeys);
+    const newText = {}
+    // keys.forEach(key => {
+    //   const page = getPage(key)
+    //   const baseFrame = `frame${page}`
+    //   if (!newText[baseFrame]) {
+    //
+    //   }
+    // })
+    //
+    // console.log('new keys', keys);
+  }
+
   function reset() {
     getRoot(self).aggregations.setModal(false)
     self.current = undefined
@@ -439,6 +455,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     reset: () => undoManager.withoutUndo(() => reset()),
     reaggregateDBScan,
     reaggregateOptics,
+    rearrangePages,
     redefineTranscription,
     retrieveTranscriptions,
     saveTranscription,

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -45,6 +45,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   page: types.optional(types.number, 0),
   showSaveTranscriptionError: types.optional(types.boolean, false),
   slopeIndex: types.optional(types.number, 0),
+  slopeDefinitions: types.optional(types.frozen(), {}),
   slopeKeys: types.array(types.string),
   totalPages: types.optional(types.number, 1),
   rawExtracts: types.array(types.frozen()),
@@ -218,6 +219,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   function getSlopeKeys() {
     const allSlopeKeys = []
+    const slopeDefinitions = {}
 
     self.current.text.forEach((frame, key) => {
       frame.forEach(r => {
@@ -225,9 +227,13 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
         if (!allSlopeKeys.includes(slopeKey)) {
           allSlopeKeys.push(slopeKey)
         }
+        if (!slopeDefinitions[slopeKey]) {
+          slopeDefinitions[slopeKey] = r.line_slope
+        }
       })
     })
     self.slopeKeys = allSlopeKeys
+    self.slopeDefinitions = slopeDefinitions
   }
 
   const getTranscriberInfo = flow(function * getTranscriberInfo(arrangedExtractsByUser) {
@@ -272,7 +278,6 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   function reset() {
     getRoot(self).aggregations.setModal(false)
-    self.getSlopeKeys()
     self.current = undefined
     self.index = 0
     self.slopeIndex = 0

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -19,7 +19,10 @@ const getToveResponse = () => Promise.resolve(
         data: TranscriptionFactory.build({
           attributes: {
             locked_by: 'ANOTHER_USER',
-            text: { frame0: [{}] }
+            text: {
+              frame0: [{ line_slope: 0, slope_label: 0 }, { line_slope: 90, slope_label: 1 }],
+              frame1: [{ line_slope: 0, slope_label: 0 }, { line_slope: 90, slope_label: 1 }]
+            }
           }
         }),
         meta: {
@@ -332,21 +335,44 @@ describe('TranscriptionsStore', function () {
         expect(unlockedTranscriptionStore.lockedByCurrentUser).toBe(true)
       })
 
+      describe('when rearranging pages', function () {
+        it('should rearrange simple pages', function () {
+          transcriptionsStore.rearrangePages(['frame1.0', 'frame0.0'])
+          expect(transcriptionsStore.current.frame_order).toEqual(['frame1', 'frame0'])
+        })
+
+        it('should rearrange complex pages', function () {
+          transcriptionsStore.rearrangePages(['frame1.0', 'frame0.0', 'frame1.1', 'frame1.2', 'frame0.1'])
+          expect(transcriptionsStore.current.frame_order).toEqual(['frame1', 'frame0', 'frame1.1', 'frame0.1'])
+        })
+      })
+
+      it('should getSlopeKeys', function () {
+        transcriptionsStore.getSlopeKeys()
+        expect(transcriptionsStore.slopeKeys).toEqual(['frame0.0', 'frame0.1', 'frame1.0', 'frame1.1'])
+        expect(transcriptionsStore.slopeDefinitions).toEqual({
+          'frame0.0': 0,
+          'frame0.1': 90,
+          'frame1.0': 0,
+          'frame1.1': 90
+        })
+      })
+
       describe('when deleting a line', function () {
         it('should not proceed without an active transcription', function () {
           const current = transcriptionsStore.current.text.get('frame0')
-          expect(current.length).toBe(1)
+          expect(current.length).toBe(2)
           transcriptionsStore.deleteCurrentLine()
-          expect(current.length).toBe(1)
+          expect(current.length).toBe(2)
           expect(patchToveSpy).not.toHaveBeenCalled()
         })
 
         it('should delete a line', function () {
           transcriptionsStore.setActiveTranscription(0)
           const current = transcriptionsStore.current.text.get('frame0')
-          expect(current.length).toBe(1)
+          expect(current.length).toBe(2)
           transcriptionsStore.deleteCurrentLine()
-          expect(current.length).toBe(0)
+          expect(current.length).toBe(1)
           expect(patchToveSpy).toHaveBeenCalled()
         })
       })


### PR DESCRIPTION
Closes #95 

[Invision Design](https://projects.invisionapp.com/d/#/console/17925240/371813757/preview) - note the blue outline is outdated

In a nutshell, this PR does two things:
- Shows all slope values for a given page, allows users to select different values, and denotes them when not 0 degrees
- Allows users to rearrange the order of these slope frames and saves the resulting order

There were many gotchas when writing this PR, but they _should_ all be resolved:
- Will the page order be rearranged to the original values when choosing to "edit aggregation settings" back to the original values? (default values under DB SCAN)
- Will the transcription retain frame order when reloading the transcription
- Will the UI show when frames with the same page number are grouped together?
- Can a user correctly "undo" a change in frame order? For this to work correctly, moving frames should only commit to the state tree when the frame drag ends (not with each move over a frame). 

Things to keep in mind during review:
- The dependency array in React's `useEffect` hook, which determines when the hook triggers, does **not** notice changes when the order of items in an array change. Ex: If my array is `[frame0, frame1, frame2]` and it changes to `[frame1, frame2, frame2]`, the hook will not register a change and `useEffect` will not fire. Thus, I had to write a custom `usePrevious` hook and check the array values were different with an `isEqual` helper function.

- With mobx state tree, using `detach` to remove unused nodes is imperative. Let's say I separated `frame0` into `frame0` and `frame0.1` by moving half of that frame to the very end of all the frames. Next, I selected that `frame0.1` at the end of the page. Finally, I decide to "edit aggregation settings" and revert back to the original reduction. When I do this, there is a split second where `frame0.1` still attempts to render, even though the reaggregation combines it back into the original `frame0` value. Mobx state tree would choke on this because `frame0.1` doesn't actually exist in the tree anymore, but it is still erroneously being referenced.