### PR TITLE
Test for Transcription Locked By Different User

### DIFF
--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -32,7 +32,7 @@ function Editor ({ match, testTime }) {
     const setResources = async () => {
       await store.subjects.fetchSubject(match.params.subject)
       await store.getResources(match.params)
-      if (!store.transcriptions.lockedByCurrentUser) {
+      if (store.transcriptions.lockedByDifferentUser) {
         store.modal.toggleModal(MODALS.LOCKED)
       }
     }
@@ -54,7 +54,7 @@ function Editor ({ match, testTime }) {
     window.addEventListener('visibilitychange', handleTimeCheck)
 
     return () => {
-      if (store.transcriptions.lockedByCurrentUser) {
+      if (!store.transcriptions.lockedByDifferentUser) {
         store.transcriptions.unlockTranscription()
       }
       window.removeEventListener('beforeunload', store.transcriptions.unlockTranscription);

--- a/src/screens/Editor/Editor.spec.js
+++ b/src/screens/Editor/Editor.spec.js
@@ -64,7 +64,7 @@ const contextValues = {
     current: undefined,
     extracts: [],
     index: 0,
-    lockedByCurrentUser: false,
+    lockedByDifferentUser: true,
     setActiveTranscription: setActiveTranscriptionSpy,
     slopeKeys: [],
     unlockTranscription: unlockTranscriptionSpy
@@ -121,7 +121,7 @@ describe('Component > Editor', function () {
       beforeEach(async function () {
         jest.clearAllMocks()
         const lockedValues = Object.assign(contextValues)
-        lockedValues.transcriptions.lockedByCurrentUser = true
+        lockedValues.transcriptions.lockedByDifferentUser = false
         jest
           .spyOn(React, 'useContext')
           .mockImplementation(() => Object.assign({}, lockedValues))

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -528,8 +528,8 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   },
 
   get lockedByDifferentUser () {
-    const user = getRoot(self).auth.userName
-    return self.current.locked_by && self.current.locked_by !== user
+    const login = getRoot(self).auth.user.login;
+    return self.current.locked_by && self.current.locked_by !== login
   },
 
   get isActive () {

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -102,7 +102,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const response = yield client.get(`/transcriptions/${self.title}`)
     const resource = JSON.parse(response.body)
     const lockedBy = resource.data.attributes.locked_by
-    const lockedByDifferentUser = lockedBy && lockedBy !== getRoot(self).auth.userName
+    const lockedByDifferentUser = lockedBy && lockedBy !== getRoot(self).auth.user.login
     if (lockedByDifferentUser) {
       getRoot(self).modal.toggleModal(MODALS.LOCKED)
     }

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -527,9 +527,9 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     return count;
   },
 
-  get lockedByCurrentUser () {
+  get lockedByDifferentUser () {
     const user = getRoot(self).auth.userName
-    return user === self.current.locked_by
+    return self.current.locked_by && self.current.locked_by !== user
   },
 
   get isActive () {

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -325,11 +325,11 @@ describe('TranscriptionsStore', function () {
         )
       })
 
-      it('should return false if the transcription is not lockedByCurrentUser', function () {
-        expect(transcriptionsStore.lockedByCurrentUser).toBe(false)
+      it('should return true if the transcription is lockedByDifferentUser', function () {
+        expect(transcriptionsStore.lockedByDifferentUser).toBe(true)
       })
 
-      it('should return true if the transcription is lockedByCurrentUser', async function () {
+      it('should return false if the transcription is not lockedByDifferentUser', async function () {
         const unlockableStore = AppStore.create({
           auth: { user: { display_name: 'A_USER' } },
           client: { tove: mockJWT(unlockedTranscriptionStub), toveZip: mockJWT() },
@@ -343,7 +343,7 @@ describe('TranscriptionsStore', function () {
         })
         const unlockedTranscriptionStore = unlockableStore.transcriptions
         await unlockedTranscriptionStore.selectTranscription(1)
-        expect(unlockedTranscriptionStore.lockedByCurrentUser).toBe(true)
+        expect(unlockedTranscriptionStore.lockedByDifferentUser).toBe(false)
       })
 
       describe('when rearranging pages', function () {

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -331,7 +331,7 @@ describe('TranscriptionsStore', function () {
 
       it('should return false if the transcription is not lockedByDifferentUser', async function () {
         const unlockableStore = AppStore.create({
-          auth: { user: { display_name: 'A_USER' } },
+          auth: { user: { login: 'A_USER' } },
           client: { tove: mockJWT(unlockedTranscriptionStub), toveZip: mockJWT() },
           groups: {
             current: { display_name: 'GROUP_1' }


### PR DESCRIPTION
I believe this should take care of the subject locking issue that was first identified in #158 

I believe `null` values were being interpreted as a transcription being locked. The check was:

- See if the current transcription's `locked_by` equals the current user
- If it does not equal, show the locked modal

What if `locked_by` is `null`, meaning it is available/unlocked?
- Check if `null` equals the current user
- It isn't equal, show the locked modal

This doesn't make sense!

This PR should rectify that issue by checking instead if the transcription is locked by a **different** user and responding accordingly. I'm not positive it should work, as I wasn't able to replicate the issue, but it should take care of what I believe the issue to be.