### PR TITLE
Adjust Metadata Modal

### DIFF
--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -47,8 +47,6 @@ function MetadataButton({
   const targetEl = React.useRef(null)
   const [isOpen, toggleDrop] = React.useState(false)
 
-  console.log('TRANSCRIPTION', transcription);
-
   const { pages, status, transcribed_lines } = transcription
 
   return (

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -98,13 +98,15 @@ function MetadataButton({
                 </colgroup>
                 <TableBody>
                 {metadata && Object.keys(metadata).map((key, i) => {
+                  const value = metadata[key]
+                  if (!value) return null
                   return (
                     <TableRow key={`METADATA_VALUE_${i}`}>
                       <TableCell>
                         <CapitalText>{key}</CapitalText>
                       </TableCell>
                       <TableCell>
-                        <StyledText>{metadata[key]}</StyledText>
+                        <StyledText>{value}</StyledText>
                       </TableCell>
                     </TableRow>
                   )

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -47,7 +47,9 @@ function MetadataButton({
   const targetEl = React.useRef(null)
   const [isOpen, toggleDrop] = React.useState(false)
 
-  const { pages, status, transcribed_lines } = transcription || {}
+  console.log('TRANSCRIPTION', transcription);
+
+  const { pages, status, transcribed_lines } = transcription
 
   return (
     <Box width='1em'>

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -38,17 +38,16 @@ const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
 
 function MetadataButton({
   disabled,
-  goldStandard,
+  goldStandardCount,
   id,
-  lines,
   metadata,
-  pages,
-  score,
-  status,
-  transcribers
+  transcriberCount,
+  transcription
 }) {
   const targetEl = React.useRef(null)
   const [isOpen, toggleDrop] = React.useState(false)
+
+  const { pages, status, transcribed_lines } = transcription
 
   return (
     <Box width='1em'>
@@ -87,7 +86,7 @@ function MetadataButton({
               </Box>
               <Box>
                 <CapitalText size='xsmall'>
-                  {pages} pages &#8226; {transcribers}/{goldStandard} transcribers/gold standard &#8226; {lines} transcribed lines &#8226; {score}/{transcribers} average consensus &#8226; {status}
+                  {pages} pages &#8226; {transcriberCount}/{goldStandardCount} transcribers/gold standard &#8226; {transcribed_lines} transcribed lines &#8226; {0}/{transcribed_lines} average consensus &#8226; {status}
                 </CapitalText>
               </Box>
             </Box>
@@ -122,24 +121,28 @@ function MetadataButton({
 
 MetadataButton.defaultProps = {
   disabled: false,
-  goldStandard: 0,
+  goldStandardCount: 0,
   id: '',
-  lines: 0,
   metadata: null,
-  pages: 0,
-  score: 0,
-  transcribers: 0
+  transcriberCount: 0,
+  transcription: {
+    pages: 0,
+    status: 'unseen',
+    transcribed_lines: 0
+  }
 }
 
 MetadataButton.propTypes = {
   disabled: bool,
-  goldStandard: number,
+  goldStandardCount: number,
   id: string,
-  lines: number,
   metadata: shape(),
-  pages: number,
-  score: number,
-  transcribers: number
+  transcriberCount: number,
+  transcription: shape({
+    pages: number,
+    status: string,
+    transcribed_lines: number
+  })
 }
 
 export { MetadataButton }

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -86,7 +86,7 @@ function MetadataButton({
               </Box>
               <Box>
                 <CapitalText size='xsmall'>
-                  {pages} pages &#8226; {transcriberCount}/{goldStandardCount} transcribers/gold standard &#8226; {transcribed_lines} transcribed lines &#8226; {0}/{transcribed_lines} average consensus &#8226; {status}
+                  {pages} pages &#8226; {transcriberCount}/{goldStandardCount} transcribers/gold standard &#8226; {transcribed_lines} transcribed lines &#8226; {status}
                 </CapitalText>
               </Box>
             </Box>

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -47,7 +47,7 @@ function MetadataButton({
   const targetEl = React.useRef(null)
   const [isOpen, toggleDrop] = React.useState(false)
 
-  const { pages, status, transcribed_lines } = transcription
+  const { pages, status, transcribed_lines } = transcription || {}
 
   return (
     <Box width='1em'>

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.spec.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.spec.js
@@ -27,7 +27,7 @@ describe('Component > MetadataButton', function () {
       wrapper = shallow(<MetadataButton metadata={mockMetadata} />)
     })
 
-    it('should render metadata when passed', function () {
+    it('should render all valid metadata', function () {
       const metadataRows = wrapper.findWhere((n) => {
         if (n.key()) {
           return n.key().includes('METADATA_VALUE')

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.js
@@ -1,21 +1,27 @@
 import React from 'react'
 import AppContext from 'store'
 import { observer } from 'mobx-react'
+import gsCountFromExtracts from 'helpers/gsCountFromExtracts'
 import MetadataButton from './MetadataButton'
 
 function MetadataButtonContainer() {
   const store = React.useContext(AppContext)
   const metadata = store.subjects.current && store.subjects.current.metadata
   const id = store.subjects.current && store.subjects.current.id
-  const status = store.transcriptions.current && store.transcriptions.current.status
   const disabled = store.aggregations.showModal || store.transcriptions.isActive
+  const transcription = store.transcriptions.current
+  const extracts = store.transcriptions.rawExtracts || []
+  const extractCount = extracts.length || 0
+  const gsCount = gsCountFromExtracts(extracts)
 
   return (
     <MetadataButton
       disabled={disabled}
+      goldStandardCount={gsCount}
       id={id}
       metadata={metadata}
-      status={status}
+      transcriberCount={extractCount}
+      transcription={transcription}
     />
   )
 }

--- a/src/components/EditorHeader/components/MetadataButton/mockMetadata.js
+++ b/src/components/EditorHeader/components/MetadataButton/mockMetadata.js
@@ -5,6 +5,7 @@ export default {
   caseid: '1985-069',
   docket: '84-1601',
   uscite: '475 U.S. 813',
+  blank_data: '',
   casename: 'AETNA LIFE INSURANCE CO v. LAVOIE et al.',
   docketid: '1985-069-01',
   image_name: '1985-WJB_84-1601_1_Marshall.jpg',

--- a/src/helpers/gsCountFromExtracts.js
+++ b/src/helpers/gsCountFromExtracts.js
@@ -1,4 +1,4 @@
-export default function gsCountFromExtracts(extracts) {
+export default function gsCountFromExtracts(extracts = []) {
   let count = 0;
   extracts.forEach(extract => {
     if (!extract.data) return

--- a/src/helpers/gsCountFromExtracts.js
+++ b/src/helpers/gsCountFromExtracts.js
@@ -1,0 +1,9 @@
+export default function gsCountFromExtracts(extracts) {
+  let count = 0;
+  extracts.forEach(extract => {
+    const values = Object.values(extract.data)
+    const isGoldStandard = values.some(data => data.gold_standard)
+    if (isGoldStandard) count++
+  })
+  return count;
+}

--- a/src/helpers/gsCountFromExtracts.js
+++ b/src/helpers/gsCountFromExtracts.js
@@ -1,6 +1,7 @@
 export default function gsCountFromExtracts(extracts) {
   let count = 0;
   extracts.forEach(extract => {
+    if (!extract.data) return
     const values = Object.values(extract.data)
     const isGoldStandard = values.some(data => data.gold_standard)
     if (isGoldStandard) count++

--- a/src/helpers/gsCountFromExtracts.spec.js
+++ b/src/helpers/gsCountFromExtracts.spec.js
@@ -1,0 +1,37 @@
+import gsCountFromExtracts from './gsCountFromExtracts'
+
+const gsExtract = {
+  data: {
+    frame0: { gold_standard: true }
+  }
+}
+
+const extract = {
+  data: {
+    frame0: { gold_standard: false }
+  }
+}
+
+const gsExtracts = new Map()
+gsExtracts.set('one', gsExtract)
+gsExtracts.set('two', gsExtract)
+gsExtracts.set('three', extract)
+
+const extracts = new Map()
+extracts.set('one', extract)
+extracts.set('two', extract)
+
+console.log(gsExtracts);
+console.log(extracts);
+
+describe('Helper > gsCountFromExtracts', function () {
+  it('should count the amount of Gold Standard extracts', function () {
+    const result = gsCountFromExtracts(gsExtracts)
+    expect(result).toBe(2)
+  })
+
+  it('should return zero when no Gold Standard extracts', function () {
+    const result = gsCountFromExtracts(extracts)
+    expect(result).toBe(0)
+  })
+})

--- a/src/helpers/gsCountFromExtracts.spec.js
+++ b/src/helpers/gsCountFromExtracts.spec.js
@@ -21,9 +21,6 @@ const extracts = new Map()
 extracts.set('one', extract)
 extracts.set('two', extract)
 
-console.log(gsExtracts);
-console.log(extracts);
-
 describe('Helper > gsCountFromExtracts', function () {
   it('should count the amount of Gold Standard extracts', function () {
     const result = gsCountFromExtracts(gsExtracts)
@@ -33,5 +30,19 @@ describe('Helper > gsCountFromExtracts', function () {
   it('should return zero when no Gold Standard extracts', function () {
     const result = gsCountFromExtracts(extracts)
     expect(result).toBe(0)
+  })
+
+  describe('incomplete extracts', function () {
+    it('should return zero', function () {
+      const result = gsCountFromExtracts([{}])
+      expect(result).toBe(0)
+    })
+  })
+
+  describe('default param', function () {
+    it('should return zero', function () {
+      const result = gsCountFromExtracts()
+      expect(result).toBe(0)
+    })
   })
 })


### PR DESCRIPTION
Closes #163 

Upon an initial audit, I noticed the metadata needed cleaning. More info in the associated issue, but this also depended on bringing a bit more transcription data into the modal.