### PR TITLE
Fix Subjects Page Pagination Issue

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -471,7 +471,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-cMljjf hwFcyK"
+      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-brqgnP jxxQpd"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 cGDWft"
@@ -496,7 +496,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
             className="StyledBox-sc-13pk1d4-0 jHQJnz"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP gxqauL"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jWBwVP HYnmJ"
             >
               Collapse
                Filmstrip
@@ -979,7 +979,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
             className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
           />
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
           >
             Find a specific subject
           </span>
@@ -997,7 +997,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 iEMnku"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1065,7 +1065,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 bgTRhM"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1103,7 +1103,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
             />
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
             >
               Filter subject list by status
             </span>
@@ -1384,7 +1384,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="button"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
                 >
                   Close
                 </span>
@@ -1399,7 +1399,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="submit"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
                 >
                   Search
                 </span>
@@ -1433,7 +1433,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
       >
         This subject cannot be accessed because 
         <strong />
@@ -1443,7 +1443,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
       >
         For access, ask them to close their version.
       </span>
@@ -1519,16 +1519,16 @@ exports[`Storyshots SubjectViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo jmYbgd"
+        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm cGINmZ"
       >
         <div
-          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-hzDkRC gvqsPE"
+          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo iWvEYT"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-Rmtcm kYmdDB"
+            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-csuQGl jfGFKk"
           />
           <div
-            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-hzDkRC sc-jhAzac fZhiDl"
+            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-bRBYWo sc-hzDkRC fcssmf"
           />
         </div>
         <div
@@ -1592,7 +1592,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         By unapproving this subject, the subject's data will be unavailable for future downloads until re-marked as approved.
       </span>
@@ -1600,7 +1600,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         This action can be reversed at any time.
       </span>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -471,7 +471,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-jAaTju lEldS"
+      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-cMljjf hwFcyK"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 cGDWft"
@@ -496,7 +496,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
             className="StyledBox-sc-13pk1d4-0 jHQJnz"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf clSTOo"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP gxqauL"
             >
               Collapse
                Filmstrip
@@ -979,7 +979,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
             className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
           />
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
           >
             Find a specific subject
           </span>
@@ -997,7 +997,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 iEMnku"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jlyJG kcnAXP"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1065,7 +1065,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 bgTRhM"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-jlyJG kcnAXP"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1103,7 +1103,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
             />
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
             >
               Filter subject list by status
             </span>
@@ -1384,7 +1384,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="button"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
                 >
                   Close
                 </span>
@@ -1399,7 +1399,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="submit"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-iRbamj jbhAcf"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
                 >
                   Search
                 </span>
@@ -1433,7 +1433,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         This subject cannot be accessed because 
         <strong />
@@ -1443,7 +1443,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         For access, ask them to close their version.
       </span>
@@ -1519,16 +1519,16 @@ exports[`Storyshots SubjectViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-hzDkRC eniHZY"
+        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo jmYbgd"
       >
         <div
-          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-jhAzac ZlZeV"
+          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-hzDkRC gvqsPE"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-bRBYWo cfFjGV"
+            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-Rmtcm kYmdDB"
           />
           <div
-            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-jhAzac sc-fBuWsC deBBpZ"
+            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-hzDkRC sc-jhAzac fZhiDl"
           />
         </div>
         <div
@@ -1592,7 +1592,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay yONTa"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         By unapproving this subject, the subject's data will be unavailable for future downloads until re-marked as approved.
       </span>
@@ -1600,7 +1600,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay yONTa"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         This action can be reversed at any time.
       </span>

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -51,6 +51,7 @@ function FilmstripViewer ({
   }
 
   const handlePageRearrangement = () => rearrangePages(slopeValues)
+  const steps = images.map((src,i) => i)
 
   return (
     <RelativeBox background='#FFFFFF' pad='xsmall' round={{ size: 'xsmall', corner: 'top' }}>
@@ -62,7 +63,8 @@ function FilmstripViewer ({
             activeStep={subjectIndex}
             disabled={disabled}
             setStep={selectImage}
-            steps={images}
+            steps={steps}
+            totalPages={steps.length}
           /> )}
         <Button
           disabled={disabled}

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -61,6 +61,7 @@ function ResourcesTable(props) {
         <StepNavigation
           activeStep={props.activeStep}
           setStep={props.setStep}
+          showLabel
           steps={props.steps}
         />
       </Box>
@@ -79,7 +80,8 @@ ResourcesTable.defaultProps = {
   searching: false,
   setStep: () => {},
   status: ASYNC_STATES.IDLE,
-  steps: []
+  steps: [],
+  totalPages: 0
 }
 
 ResourcesTable.propTypes = {
@@ -92,7 +94,8 @@ ResourcesTable.propTypes = {
   searching: PropTypes.bool,
   setStep: PropTypes.func,
   steps: PropTypes.array,
-  status: PropTypes.string
+  status: PropTypes.string,
+  totalPages: PropTypes.number
 }
 
 export default withRouter(ResourcesTable)

--- a/src/components/ResourcesTable/ResourcesTable.js
+++ b/src/components/ResourcesTable/ResourcesTable.js
@@ -63,6 +63,7 @@ function ResourcesTable(props) {
           setStep={props.setStep}
           showLabel
           steps={props.steps}
+          totalPages={props.totalPages}
         />
       </Box>
     </Box>

--- a/src/components/StepNavigation/StepNavigation.js
+++ b/src/components/StepNavigation/StepNavigation.js
@@ -21,8 +21,15 @@ const StyledButton = styled(Button)`
 const StyledRadioButtonGroup = styled(RadioButtonGroup)`
   position: relative;
   > label {
+    display: flex;
+    flex-direction: column;
+
     > div {
-      margin-right: 10px;
+      margin: 0 0.25em;
+    }
+
+    > span {
+      font-size: 0.75em;
     }
   }
 `
@@ -35,17 +42,19 @@ class StepNavigation extends React.Component {
   }
 
   render () {
-    const { activeStep, disabled, setStep, steps } = this.props
+    const { activeStep, disabled, setStep, showLabel, steps } = this.props
     if (steps && steps.length > 1) {
       const nextStep = activeStep + 1
       const prevStep = activeStep - 1
       const options = steps.map((step, index) => {
+        const showPage = showLabel && !isNaN(step)
         // We can't just use index for the value
         // because Grommet is using indexes internally as keys and this will error with a duplicate key
-        const value = `step-${index}`
+        const value = `step-${showPage ? step : index}`
         return {
           disabled,
           id: value,
+          label: showPage ? (step + 1).toString() : null,
           value
         }
       })
@@ -84,6 +93,7 @@ StepNavigation.defaultProps = {
   activeStep: 0,
   disabled: false,
   setStep: () => {},
+  showLabel: false,
   steps: []
 }
 
@@ -91,6 +101,7 @@ StepNavigation.propTypes = {
   activeStep: PropTypes.number,
   disabled: PropTypes.bool,
   setStep: PropTypes.func,
+  showLabel: PropTypes.bool,
   steps: PropTypes.array
 }
 

--- a/src/components/StepNavigation/StepNavigation.js
+++ b/src/components/StepNavigation/StepNavigation.js
@@ -1,30 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Box, RadioButtonGroup, Text } from 'grommet'
+import { Button, Box, RadioButton, RadioButtonGroup, Text } from 'grommet'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faAngleLeft,
   faAngleRight,
-  faAngleDoubleLeft,
-  faAngleDoubleRight
 } from '@fortawesome/free-solid-svg-icons'
-import styled from 'styled-components'
-
-const StyledRadioButtonGroup = styled(RadioButtonGroup)`
-  position: relative;
-  > label {
-    display: flex;
-    flex-direction: column;
-
-    > div {
-      margin: 0 0.25em;
-    }
-
-    > span {
-      font-size: 0.75em;
-    }
-  }
-`
 
 class StepNavigation extends React.Component {
   onChange (event) {
@@ -50,14 +31,7 @@ class StepNavigation extends React.Component {
         }
       })
       return (
-        <Box direction='row' gap='xsmall'>
-          <Button
-            data-index={0}
-            disabled={activeStep === 0}
-            icon={<FontAwesomeIcon icon={faAngleDoubleLeft} />}
-            onClick={() => setStep(0)}
-            plain
-          />
+        <Box direction='row' gap='xxsmall'>
           <Button
             data-index={prevStep}
             disabled={activeStep === 0}
@@ -66,31 +40,40 @@ class StepNavigation extends React.Component {
             plain
           />
 
-          <Box direction='row'>
-            {activeStep > 2 && <Text>...</Text>}
-            <StyledRadioButtonGroup
-              direction='row'
-              gap='none'
-              name='step-selectors'
-              onChange={this.onChange.bind(this)}
-              options={options}
-              value={`step-${activeStep}`}
-            />
-            {activeStep < totalPages - 3 && <Text>...</Text>}
-          </Box>
+          {activeStep > 2 && (
+            <Box direction='row' gap='xxsmall'>
+              <RadioButton
+                onClick={() => setStep(0)}
+                label={1}
+                name="First Page"
+              />
+              <Text>...</Text>
+            </Box>
+          )}
+          <RadioButtonGroup
+            direction='row'
+            gap='none'
+            name='step-selectors'
+            onChange={this.onChange.bind(this)}
+            options={options}
+            value={`step-${activeStep}`}
+          />
+          {activeStep < totalPages - 3 && (
+            <Box direction='row' gap='xxsmall'>
+              <Text>...</Text>
+              <RadioButton
+                onClick={() => setStep(totalPages - 1)}
+                label={totalPages}
+                name="Last Page"
+              />
+            </Box>
+          )}
 
           <Button
             data-index={nextStep}
             disabled={activeStep === totalPages - 1}
             icon={<FontAwesomeIcon icon={faAngleRight} />}
             onClick={() => setStep(nextStep)}
-            plain
-          />
-          <Button
-            data-index={totalPages - 1}
-            disabled={activeStep === totalPages - 1}
-            icon={<FontAwesomeIcon icon={faAngleDoubleRight} />}
-            onClick={() => setStep(totalPages - 1)}
             plain
           />
         </Box>
@@ -117,5 +100,4 @@ StepNavigation.propTypes = {
   totalPages: PropTypes.number.isRequired
 }
 
-export { StyledRadioButtonGroup }
 export default StepNavigation

--- a/src/components/StepNavigation/StepNavigation.js
+++ b/src/components/StepNavigation/StepNavigation.js
@@ -9,7 +9,6 @@ import {
   faAngleDoubleRight
 } from '@fortawesome/free-solid-svg-icons'
 import styled from 'styled-components'
-import { FormPrevious, FormNext } from 'grommet-icons'
 
 const StyledRadioButtonGroup = styled(RadioButtonGroup)`
   position: relative;
@@ -51,7 +50,7 @@ class StepNavigation extends React.Component {
         }
       })
       return (
-        <Box direction='row'>
+        <Box direction='row' gap='xsmall'>
           <Button
             data-index={0}
             disabled={activeStep === 0}
@@ -66,14 +65,20 @@ class StepNavigation extends React.Component {
             onClick={() => setStep(prevStep)}
             plain
           />
-          <StyledRadioButtonGroup
-            direction='row'
-            gap='none'
-            name='step-selectors'
-            onChange={this.onChange.bind(this)}
-            options={options}
-            value={`step-${activeStep}`}
-          />
+
+          <Box direction='row'>
+            {activeStep > 2 && <Text>...</Text>}
+            <StyledRadioButtonGroup
+              direction='row'
+              gap='none'
+              name='step-selectors'
+              onChange={this.onChange.bind(this)}
+              options={options}
+              value={`step-${activeStep}`}
+            />
+            {activeStep < totalPages - 3 && <Text>...</Text>}
+          </Box>
+
           <Button
             data-index={nextStep}
             disabled={activeStep === totalPages - 1}

--- a/src/components/StepNavigation/StepNavigation.js
+++ b/src/components/StepNavigation/StepNavigation.js
@@ -11,13 +11,6 @@ import {
 import styled from 'styled-components'
 import { FormPrevious, FormNext } from 'grommet-icons'
 
-const StyledButton = styled(Button)`
-  &:first-of-type {
-    margin: 0 10px 0 0;
-    padding: 0;
-  }
-`
-
 const StyledRadioButtonGroup = styled(RadioButtonGroup)`
   position: relative;
   > label {
@@ -42,28 +35,34 @@ class StepNavigation extends React.Component {
   }
 
   render () {
-    const { activeStep, disabled, setStep, showLabel, steps } = this.props
+    const { activeStep, disabled, setStep, showLabel, steps, totalPages } = this.props
     if (steps && steps.length > 1) {
       const nextStep = activeStep + 1
       const prevStep = activeStep - 1
       const options = steps.map((step, index) => {
-        const showPage = showLabel && !isNaN(step)
         // We can't just use index for the value
         // because Grommet is using indexes internally as keys and this will error with a duplicate key
-        const value = `step-${showPage ? step : index}`
+        const value = `step-${step}`
         return {
           disabled,
           id: value,
-          label: showPage ? (step + 1).toString() : null,
+          label: showLabel ? (step + 1).toString() : null,
           value
         }
       })
       return (
         <Box direction='row'>
-          <StyledButton
+          <Button
+            data-index={0}
+            disabled={activeStep === 0}
+            icon={<FontAwesomeIcon icon={faAngleDoubleLeft} />}
+            onClick={() => setStep(0)}
+            plain
+          />
+          <Button
             data-index={prevStep}
             disabled={activeStep === 0}
-            icon={<FormPrevious />}
+            icon={<FontAwesomeIcon icon={faAngleLeft} />}
             onClick={() => setStep(prevStep)}
             plain
           />
@@ -75,11 +74,18 @@ class StepNavigation extends React.Component {
             options={options}
             value={`step-${activeStep}`}
           />
-          <StyledButton
+          <Button
             data-index={nextStep}
-            disabled={activeStep === steps.length - 1}
-            icon={<FormNext />}
+            disabled={activeStep === totalPages - 1}
+            icon={<FontAwesomeIcon icon={faAngleRight} />}
             onClick={() => setStep(nextStep)}
+            plain
+          />
+          <Button
+            data-index={totalPages - 1}
+            disabled={activeStep === totalPages - 1}
+            icon={<FontAwesomeIcon icon={faAngleDoubleRight} />}
+            onClick={() => setStep(totalPages - 1)}
             plain
           />
         </Box>
@@ -102,8 +108,9 @@ StepNavigation.propTypes = {
   disabled: PropTypes.bool,
   setStep: PropTypes.func,
   showLabel: PropTypes.bool,
-  steps: PropTypes.array
+  steps: PropTypes.array,
+  totalPages: PropTypes.number.isRequired
 }
 
-export { StyledButton, StyledRadioButtonGroup }
+export { StyledRadioButtonGroup }
 export default StepNavigation

--- a/src/components/StepNavigation/StepNavigation.js
+++ b/src/components/StepNavigation/StepNavigation.js
@@ -17,6 +17,7 @@ class StepNavigation extends React.Component {
   render () {
     const { activeStep, disabled, setStep, showLabel, steps, totalPages } = this.props
     if (steps && steps.length > 1) {
+      const currentStepAboveTwo = activeStep > 2
       const nextStep = activeStep + 1
       const prevStep = activeStep - 1
       const options = steps.map((step, index) => {
@@ -40,7 +41,7 @@ class StepNavigation extends React.Component {
             plain
           />
 
-          {activeStep > 2 && (
+          {currentStepAboveTwo && (
             <Box direction='row' gap='xxsmall'>
               <RadioButton
                 onClick={() => setStep(0)}

--- a/src/components/StepNavigation/StepNavigation.js
+++ b/src/components/StepNavigation/StepNavigation.js
@@ -1,6 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Box, RadioButtonGroup } from 'grommet'
+import { Button, Box, RadioButtonGroup, Text } from 'grommet'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  faAngleLeft,
+  faAngleRight,
+  faAngleDoubleLeft,
+  faAngleDoubleRight
+} from '@fortawesome/free-solid-svg-icons'
 import styled from 'styled-components'
 import { FormPrevious, FormNext } from 'grommet-icons'
 

--- a/src/components/StepNavigation/StepNavigation.spec.js
+++ b/src/components/StepNavigation/StepNavigation.spec.js
@@ -1,10 +1,11 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import StepNavigation, { StyledButton, StyledRadioButtonGroup } from './StepNavigation'
+import { Button } from 'grommet'
+import StepNavigation, { StyledRadioButtonGroup } from './StepNavigation'
 
 let wrapper
 const setStepSpy = jest.fn()
-const steps = ['one', 'two', 'three']
+const steps = [1, 2, 3]
 
 describe('Component > StepNavigation', function () {
   beforeEach(function() {
@@ -12,6 +13,7 @@ describe('Component > StepNavigation', function () {
       <StepNavigation
         setStep={setStepSpy}
         steps={steps}
+        totalPages={3}
       />);
   })
 
@@ -29,17 +31,17 @@ describe('Component > StepNavigation', function () {
       }
     }
     buttons.onChange(mockEvent)
-    expect(setStepSpy).toHaveBeenCalledWith(0)
+    expect(setStepSpy).toHaveBeenCalled()
   })
 
   it('should move back a step', function () {
-    const leftButton = wrapper.find(StyledButton).first().props()
+    const leftButton = wrapper.find(Button).first().props()
     leftButton.onClick()
     expect(setStepSpy).toHaveBeenCalledWith(leftButton['data-index'])
   })
 
   it('should move forward a step', function () {
-    const rightButton = wrapper.find(StyledButton).last().props()
+    const rightButton = wrapper.find(Button).last().props()
     rightButton.onClick()
     expect(setStepSpy).toHaveBeenCalledWith(rightButton['data-index'])
   })

--- a/src/components/StepNavigation/StepNavigation.spec.js
+++ b/src/components/StepNavigation/StepNavigation.spec.js
@@ -1,11 +1,11 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { Button } from 'grommet'
+import { Button, Text } from 'grommet'
 import StepNavigation, { StyledRadioButtonGroup } from './StepNavigation'
 
 let wrapper
 const setStepSpy = jest.fn()
-const steps = [1, 2, 3]
+const steps = [0, 1, 2, 3, 4, 5, 6]
 
 describe('Component > StepNavigation', function () {
   beforeEach(function() {
@@ -13,7 +13,7 @@ describe('Component > StepNavigation', function () {
       <StepNavigation
         setStep={setStepSpy}
         steps={steps}
-        totalPages={3}
+        totalPages={7}
       />);
   })
 
@@ -34,16 +34,34 @@ describe('Component > StepNavigation', function () {
     expect(setStepSpy).toHaveBeenCalled()
   })
 
-  it('should move back a step', function () {
+  it('should move to the beginning', function () {
     const leftButton = wrapper.find(Button).first().props()
     leftButton.onClick()
     expect(setStepSpy).toHaveBeenCalledWith(leftButton['data-index'])
   })
 
+  it('should move back a step', function () {
+    const leftButton = wrapper.find(Button).at(1).props()
+    leftButton.onClick()
+    expect(setStepSpy).toHaveBeenCalledWith(leftButton['data-index'])
+  })
+
   it('should move forward a step', function () {
+    const rightButton = wrapper.find(Button).at(2).props()
+    rightButton.onClick()
+    expect(setStepSpy).toHaveBeenCalledWith(rightButton['data-index'])
+  })
+
+  it('should move to the last step', function () {
     const rightButton = wrapper.find(Button).last().props()
     rightButton.onClick()
     expect(setStepSpy).toHaveBeenCalledWith(rightButton['data-index'])
+  })
+
+  it('should show ellipses to left and right', function () {
+    wrapper.setProps({ activeStep: 3 })
+    const ellipses = wrapper.find(Text)
+    expect(ellipses.length).toBe(2)
   })
 })
 

--- a/src/components/StepNavigation/StepNavigation.spec.js
+++ b/src/components/StepNavigation/StepNavigation.spec.js
@@ -1,11 +1,12 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { Button, RadioButtonGroup, Text } from 'grommet'
+import { Button, RadioButton, RadioButtonGroup, Text } from 'grommet'
 import StepNavigation from './StepNavigation'
 
 let wrapper
 const setStepSpy = jest.fn()
 const steps = [0, 1, 2, 3, 4, 5, 6]
+const TOTAL_PAGES = 7
 
 describe('Component > StepNavigation', function () {
   beforeEach(function() {
@@ -13,7 +14,7 @@ describe('Component > StepNavigation', function () {
       <StepNavigation
         setStep={setStepSpy}
         steps={steps}
-        totalPages={7}
+        totalPages={TOTAL_PAGES}
       />);
   })
 
@@ -34,34 +35,43 @@ describe('Component > StepNavigation', function () {
     expect(setStepSpy).toHaveBeenCalled()
   })
 
-  it('should move to the beginning', function () {
+  it('should move back a step', function () {
     const leftButton = wrapper.find(Button).first().props()
     leftButton.onClick()
     expect(setStepSpy).toHaveBeenCalledWith(leftButton['data-index'])
   })
 
-  it('should move back a step', function () {
-    const leftButton = wrapper.find(Button).at(1).props()
-    leftButton.onClick()
-    expect(setStepSpy).toHaveBeenCalledWith(leftButton['data-index'])
-  })
-
   it('should move forward a step', function () {
-    const rightButton = wrapper.find(Button).at(2).props()
-    rightButton.onClick()
-    expect(setStepSpy).toHaveBeenCalledWith(rightButton['data-index'])
-  })
-
-  it('should move to the last step', function () {
     const rightButton = wrapper.find(Button).last().props()
     rightButton.onClick()
     expect(setStepSpy).toHaveBeenCalledWith(rightButton['data-index'])
   })
 
-  it('should show ellipses to left and right', function () {
-    wrapper.setProps({ activeStep: 3 })
-    const ellipses = wrapper.find(Text)
-    expect(ellipses.length).toBe(2)
+  describe('with first and last pages', function () {
+    let ellipses, radioButtons;
+
+    beforeEach(function () {
+      wrapper.setProps({ activeStep: 3 })
+      ellipses = wrapper.find(Text)
+      radioButtons = wrapper.find(RadioButton)
+    })
+
+    it('should show the pages', function () {
+      expect(ellipses.length).toBe(2)
+      expect(radioButtons.length).toBe(2)
+    })
+
+    describe('onClick', function () {
+      it('should show go to the first page', function () {
+        radioButtons.first().simulate('click')
+        expect(setStepSpy).toHaveBeenCalledWith(0)
+      })
+
+      it('should show go to the last page', function () {
+        radioButtons.last().simulate('click')
+        expect(setStepSpy).toHaveBeenCalledWith(TOTAL_PAGES - 1)
+      })
+    })
   })
 })
 

--- a/src/components/StepNavigation/StepNavigation.spec.js
+++ b/src/components/StepNavigation/StepNavigation.spec.js
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { Button, Text } from 'grommet'
-import StepNavigation, { StyledRadioButtonGroup } from './StepNavigation'
+import { Button, RadioButtonGroup, Text } from 'grommet'
+import StepNavigation from './StepNavigation'
 
 let wrapper
 const setStepSpy = jest.fn()
@@ -24,7 +24,7 @@ describe('Component > StepNavigation', function () {
   })
 
   it('should execute the onChange function', function () {
-    const buttons = wrapper.find(StyledRadioButtonGroup).first().props()
+    const buttons = wrapper.find(RadioButtonGroup).first().props()
     const mockEvent = {
       target: {
         value: buttons.options[0].id

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -8,13 +8,12 @@ import ResourcesTable from '../../components/ResourcesTable'
 import { columns } from './table'
 
 function slicePages(page, pages) {
-  const leftPage = page - 2 < 0 ? 0 : page - 2
-  const rightPage = leftPage + 5
+  let leftPage = page - 2 < 0 ? 0 : page - 2
+  let rightPage = leftPage + 5
   if (pages.length > 5 && rightPage > pages.length - 1) {
     leftPage = pages.length - 5
     rightPage = pages.length
   }
-  console.log(leftPage, rightPage);
   return pages.slice(leftPage, rightPage)
 }
 
@@ -45,9 +44,6 @@ function SubjectsPageContainer ({ history, match }) {
   }
 
   const transcriptions = Array.from(store.transcriptions.all.values())
-  console.log('total pages = ', totalPages);
-  console.log('pages = ', pages);
-  console.log('page = ', page);
 
   return (
     <Box margin='medium' fill='vertical'>

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -14,14 +14,13 @@ function slicePages(page, pages) {
     leftPage = pages.length - 5
     rightPage = pages.length
   }
+  console.log(leftPage, rightPage);
   return pages.slice(leftPage, rightPage)
 }
 
 function SubjectsPageContainer ({ history, match }) {
   const store = React.useContext(AppContext)
-
   const { page, totalPages } = store.transcriptions
-
   const allPages = Array.from(Array(totalPages).keys())
   const [pages, setPages] = React.useState(allPages)
 
@@ -41,11 +40,14 @@ function SubjectsPageContainer ({ history, match }) {
   }
 
   const onSetPage = (page) => {
-    setPages(slicePages(page, allPages))
     store.transcriptions.fetchTranscriptions(page)
+    setPages(slicePages(page, allPages))
   }
 
   const transcriptions = Array.from(store.transcriptions.all.values())
+  console.log('total pages = ', totalPages);
+  console.log('pages = ', pages);
+  console.log('page = ', page);
 
   return (
     <Box margin='medium' fill='vertical'>
@@ -60,6 +62,7 @@ function SubjectsPageContainer ({ history, match }) {
         setStep={onSetPage}
         status={store.transcriptions.asyncState}
         steps={pages}
+        totalPages={totalPages}
       />
     </Box>
   )

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -7,12 +7,14 @@ import { EDIT_PATH } from 'paths'
 import ResourcesTable from '../../components/ResourcesTable'
 import { columns } from './table'
 
+const MAX_SHOWN_PAGES = 5
+
 function slicePages(page, totalPages) {
   const allPages = Array.from(Array(totalPages).keys())
   let leftPage = page - 2 < 0 ? 0 : page - 2
-  let rightPage = leftPage + 5
-  if (totalPages > 5 && rightPage > totalPages - 1) {
-    leftPage = totalPages - 5
+  let rightPage = leftPage + MAX_SHOWN_PAGES
+  if (totalPages > MAX_SHOWN_PAGES && rightPage > totalPages - 1) {
+    leftPage = totalPages - MAX_SHOWN_PAGES
     rightPage = totalPages
   }
   return allPages.slice(leftPage, rightPage)

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.js
@@ -7,21 +7,21 @@ import { EDIT_PATH } from 'paths'
 import ResourcesTable from '../../components/ResourcesTable'
 import { columns } from './table'
 
-function slicePages(page, pages) {
+function slicePages(page, totalPages) {
+  const allPages = Array.from(Array(totalPages).keys())
   let leftPage = page - 2 < 0 ? 0 : page - 2
   let rightPage = leftPage + 5
-  if (pages.length > 5 && rightPage > pages.length - 1) {
-    leftPage = pages.length - 5
-    rightPage = pages.length
+  if (totalPages > 5 && rightPage > totalPages - 1) {
+    leftPage = totalPages - 5
+    rightPage = totalPages
   }
-  return pages.slice(leftPage, rightPage)
+  return allPages.slice(leftPage, rightPage)
 }
 
 function SubjectsPageContainer ({ history, match }) {
   const store = React.useContext(AppContext)
   const { page, totalPages } = store.transcriptions
-  const allPages = Array.from(Array(totalPages).keys())
-  const [pages, setPages] = React.useState(allPages)
+  const [pages, setPages] = React.useState([])
 
   React.useEffect(() => {
     const setResources = async () => {
@@ -31,7 +31,7 @@ function SubjectsPageContainer ({ history, match }) {
     setResources()
   }, [match, store])
 
-  React.useEffect(() => setPages(slicePages(0, allPages)), [totalPages])
+  React.useEffect(() => setPages(slicePages(0, totalPages)), [totalPages])
 
   const onSelection = (transcription) => {
     const nextPath = generatePath(EDIT_PATH, { subject: transcription.id, ...match.params})
@@ -40,7 +40,7 @@ function SubjectsPageContainer ({ history, match }) {
 
   const onSetPage = (page) => {
     store.transcriptions.fetchTranscriptions(page)
-    setPages(slicePages(page, allPages))
+    setPages(slicePages(page, totalPages))
   }
 
   const transcriptions = Array.from(store.transcriptions.all.values())

--- a/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
+++ b/src/screens/SubjectsIndex/SubjectsPageContainer.spec.js
@@ -26,7 +26,8 @@ const contextValues = {
   transcriptions: {
     all: { values: () => [] },
     asyncState: ASYNC_STATES.IDLE,
-    fetchTranscriptions: fetchTranscriptionsSpy
+    fetchTranscriptions: fetchTranscriptionsSpy,
+    totalPages: 8
   }
 }
 const history = {
@@ -65,10 +66,16 @@ describe('Component > SubjectsPageContainer', function () {
       expect(pushSpy).toHaveBeenCalled()
     })
 
-    it('should call the child setStep prop', function () {
+    it('should slice pages to the next step', function () {
       const table = wrapper.find(ResourcesTable).first()
       table.props().setStep(1)
-      expect(fetchTranscriptionsSpy).toHaveBeenCalled()
+      expect(fetchTranscriptionsSpy).toHaveBeenCalledWith(1)
+    })
+
+    it('should slice pages to the final step', function () {
+      const table = wrapper.find(ResourcesTable).first()
+      table.props().setStep(7)
+      expect(fetchTranscriptionsSpy).toHaveBeenCalledWith(7)
     })
 
     it('should not toggleModal when subject unlocked', function() {

--- a/src/theme.js
+++ b/src/theme.js
@@ -104,6 +104,17 @@ const theme = {
       background: 'rgba(225, 225, 225, 0.75)'
     }
   },
+  radioButton: {
+    extend: props => css`
+      display: flex;
+      flex-direction: column;
+      font-size: 0.75em;
+
+      > div {
+        margin: 0 0.1em;
+      }
+    `
+  },
   select: {
     icons: {
       color: 'black'


### PR DESCRIPTION
This fixes an issue with pagination on the transcriptions container. What was once appearing as this:

<img width="463" alt="Screen Shot 2020-05-29 at 11 27 24 AM" src="https://user-images.githubusercontent.com/14099077/83541842-ca6be980-a4bf-11ea-851f-72aad0ef83dc.png">

Should now look like this (apologize for the quick scrolling in the video):

![Paginate](https://user-images.githubusercontent.com/14099077/83542321-67c71d80-a4c0-11ea-80b8-f09c066e69d7.gif)
