### PR TITLE
Fix Issues with Extracts

### DIFF
--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
@@ -45,7 +45,7 @@ function TranscriptionTable ({ activeSlope, data, isViewer, setActiveTranscripti
       </Box>
       <Box pad={{ bottom: 'xsmall' }}>
         {dataArray.map((datum, i) => {
-          if (datum.line_slope && datum.line_slope !== activeSlope) return null
+          if (datum.line_slope !== null && datum.line_slope !== activeSlope) return null
           return (
             <TranscriptionTableRow
               data={dataArray}

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
@@ -45,7 +45,7 @@ function TranscriptionTable ({ activeSlope, data, isViewer, setActiveTranscripti
       </Box>
       <Box pad={{ bottom: 'xsmall' }}>
         {dataArray.map((datum, i) => {
-          if (activeSlope !== datum.line_slope) return null
+          if (datum.line_slope && datum.line_slope !== activeSlope) return null
           return (
             <TranscriptionTableRow
               data={dataArray}

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.spec.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.spec.js
@@ -25,7 +25,7 @@ describe('Component > TranscriptionTable', function () {
 
   it('should hide rows without a matching slope', function () {
     wrapper = shallow(<TranscriptionTable activeSlope={90} data={mockData} />);
-    expect(0).toEqual(wrapper.find(TranscriptionTableRow).length)
+    expect(wrapper.find(TranscriptionTableRow).length).toEqual(0)
   })
 
   describe('useEffect hook', function () {

--- a/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
+++ b/src/components/SubjectViewer/components/AnnotationsPane/AnnotationsPaneContainer.js
@@ -19,6 +19,7 @@ function AnnotationsPaneContainer({ x, y }) {
     <AnnotationsPane
       activeSlope={store.transcriptions.activeSlope}
       activeTranscriptionIndex={store.transcriptions.activeTranscriptionIndex}
+      extractLines={store.transcriptions.parsedExtracts}
       isApproved={store.transcriptions.approved}
       linesVisible={store.editor.linesVisible}
       onLineClick={onLineClick}

--- a/src/helpers/parseTranscriptionData.js
+++ b/src/helpers/parseTranscriptionData.js
@@ -57,7 +57,8 @@ function mapExtractsToReductions(
         const extractSlope = classification[currentFrame].slope[extractIndex]
 
         const reductionSlope = reduction.line_slope
-        const similarSlope = Math.abs(Math.abs(extractSlope) - Math.abs(reductionSlope)) < SLOPE_BUFFER
+        const slopeDifference = Math.abs(Math.abs(extractSlope) - Math.abs(reductionSlope))
+        const similarSlope = Math.abs((slopeDifference + 180) % 360 - 180) < SLOPE_BUFFER
         const isMatch = text && text[0] === reductionText[reductionIndex][idIndex]
         // see if that text exists and if it matches the reductionText
         if (isMatch && similarSlope) {

--- a/src/store/Reduction.js
+++ b/src/store/Reduction.js
@@ -12,7 +12,7 @@ const Reduction = types.model('Reduction', {
   gold_standard: types.array(types.boolean),
   gutter_label: types.optional(types.integer, 0),
   line_editor: types.optional(types.string, ''),
-  line_slope: types.optional(types.number, 0),
+  line_slope: types.maybeNull(types.number),
   low_consensus: types.optional(types.boolean, false),
   number_views: types.optional(types.integer, 0),
   original_transcriber: types.optional(types.string, ''),

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -416,7 +416,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   function setParsedExtracts(arrangedExtractsByUser) {
     const extracts = []
     const extractsByUser = arrangedExtractsByUser || self.arrangeExtractsByUser()
-    const transcriptionFrame = self.current && self.current.text && self.current.text.get(`frame${self.index}`)
+    const transcriptionFrame = self.currentTranscriptions
     const reductionText = transcriptionFrame && transcriptionFrame.map(transcription => constructText(transcription))
     transcriptionFrame && transcriptionFrame.forEach((reduction, reductionIndex) => {
       extracts.push(mapExtractsToReductions(extractsByUser, reduction, reductionIndex, reductionText, self.index, self.extractUsers))

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -425,7 +425,12 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   function setTextObject(text) {
-    self.current.text.set(`frame${self.index}`, text)
+    if (self.current.text.get(`frame${self.index}.${self.slopeIndex}`)) {
+      self.current.text.set(`frame${self.index}.${self.slopeIndex}`, text)
+    } else {
+      self.current.text.set(`frame${self.index}`, text)
+    }
+
     self.setParsedExtracts()
     self.saveTranscription()
   }

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -72,7 +72,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   function addLine(index) {
-    const page = self.current.text.get(`frame${self.index}`)
+    const page = self.current.text.get(self.currentKey)
     if (!page) return
     const location = index ? index : page.length
     const newLine = Reduction.create()
@@ -134,7 +134,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   function deleteCurrentLine() {
     if (Number.isInteger(self.activeTranscriptionIndex)) {
-      const page = self.current.text.get(`frame${self.index}`)
+      const page = self.current.text.get(self.currentKey)
       page.splice(self.activeTranscriptionIndex, 1)
       self.saveTranscription()
       self.setActiveTranscription()
@@ -425,12 +425,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   }
 
   function setTextObject(text) {
-    if (self.current.text.get(`frame${self.index}.${self.slopeIndex}`)) {
-      self.current.text.set(`frame${self.index}.${self.slopeIndex}`, text)
-    } else {
-      self.current.text.set(`frame${self.index}`, text)
-    }
-
+    self.current.text.set(self.currentKey, text)
     self.setParsedExtracts()
     self.saveTranscription()
   }
@@ -543,9 +538,13 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
   get currentTranscriptions () {
     const current = self.current && self.current.text &&
-      (self.current.text.get(`frame${self.index}.${self.slopeIndex}`) ||
-       self.current.text.get(`frame${self.index}`))
+      self.current.text.get(self.currentKey)
     return current || []
+  },
+
+  get currentKey () {
+    return self.current.text.get(`frame${self.index}.${self.slopeIndex}`) ?
+      `frame${self.index}.${self.slopeIndex}` : `frame${self.index}`
   },
 
   get readyForReview () {


### PR DESCRIPTION
There were a few bugs with extracts that this PR aims to fix:

- Add extracts lines back to the subject (erroneously removed in #158)
- Fix several issues with adjusting frames with sub-keys (ex: `frame0.0`, `frame0.1`, etc.)
    - Allow lines to be added
    - Allow lines to be deleted
    - Allow lines to be reordered
