### PR TITLE
Adjust Subjects Page Container Headers

### DIFF
--- a/src/screens/SubjectsIndex/table.js
+++ b/src/screens/SubjectsIndex/table.js
@@ -50,13 +50,13 @@ const columns = [
     render: datum => datum.flagged ? <Box><StyledFontAwesomeIcon color='tomato' icon={faCircle} /></Box> : null
   },
   {
-    property: "consensusScore",
+    property: "lowConsensusLines",
     header: (
-      <HeaderButton property='low_consensus_lines' title='CONSENSUS SCORE' />
+      <HeaderButton property='low_consensus_lines' title='LOW CONSENSUS LINES' />
     ),
     render: datum => {
       const color = datum.consensusScore <= datum.classifications / 2 ? 'red' : 'inherit'
-      return <Text color={color}>{datum.low_consensus_lines}/{datum.transcribed_lines}</Text>
+      return <Text color={color}>{datum.low_consensus_lines}</Text>
     }
   },
   {


### PR DESCRIPTION
This is a quick change to fix the headers of the subjects page container based on a recent call. To match the following:
<img width="311" alt="Screen Shot 2020-06-09 at 3 56 19 PM" src="https://user-images.githubusercontent.com/14099077/84198953-f829d300-aa69-11ea-9406-51b514ac2d3b.png">

Original headers:
<img width="287" alt="Screen Shot 2020-06-09 at 4 00 16 PM" src="https://user-images.githubusercontent.com/14099077/84199202-5951a680-aa6a-11ea-9097-501cfdf1c5af.png">

The new header reads "Low Consensus Lines," whereas before it read "Consensus Score," but was pretty vague and was basically a fraction of `low_consensus_lines/transcribed_lines`. The following column already includes "Transcribed Lines," so listing it twice was redundant.