### PR TITLE
Show Zoom/Rotate Tools with Active Line

### DIFF
--- a/src/components/SubjectViewer/SubjectViewerContainer.js
+++ b/src/components/SubjectViewer/SubjectViewerContainer.js
@@ -43,7 +43,7 @@ function SubjectViewerContainer() {
         <AbsoluteBox fill>
           <AsyncMessages error={store.subjects.error} subjectState={store.subjects.asyncState} />
           <ToolsBox>
-            {showTools && !store.transcriptions.isActive && <ImageTools />}
+            {showTools && <ImageTools />}
           </ToolsBox>
         </AbsoluteBox>
         <SVGView />


### PR DESCRIPTION
This PR shows the zoom and rotate tools at all times. Previously, the tools were disabled when the modal was open to edit a line.