### PR TITLE
Disable Filmstrip Thumbnail Reordering with Approved Subjects

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -471,7 +471,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-brqgnP jxxQpd"
+      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-cMljjf hwFcyK"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 cGDWft"
@@ -496,7 +496,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
             className="StyledBox-sc-13pk1d4-0 jHQJnz"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jWBwVP HYnmJ"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP gxqauL"
             >
               Collapse
                Filmstrip
@@ -979,7 +979,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
             className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
           />
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
           >
             Find a specific subject
           </span>
@@ -997,7 +997,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 iEMnku"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1065,7 +1065,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 bgTRhM"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1103,7 +1103,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
             />
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
             >
               Filter subject list by status
             </span>
@@ -1384,7 +1384,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="button"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
                 >
                   Close
                 </span>
@@ -1399,7 +1399,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="submit"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
                 >
                   Search
                 </span>
@@ -1433,7 +1433,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         This subject cannot be accessed because 
         <strong />
@@ -1443,7 +1443,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         For access, ask them to close their version.
       </span>
@@ -1519,16 +1519,16 @@ exports[`Storyshots SubjectViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm cGINmZ"
+        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo jmYbgd"
       >
         <div
-          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo iWvEYT"
+          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-hzDkRC gvqsPE"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-csuQGl jfGFKk"
+            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-Rmtcm kYmdDB"
           />
           <div
-            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-bRBYWo sc-hzDkRC fcssmf"
+            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-hzDkRC sc-jhAzac fZhiDl"
           />
         </div>
         <div
@@ -1592,7 +1592,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         By unapproving this subject, the subject's data will be unavailable for future downloads until re-marked as approved.
       </span>
@@ -1600,7 +1600,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         This action can be reversed at any time.
       </span>

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButton.js
@@ -14,6 +14,7 @@ import { faInfo, faTimesCircle } from '@fortawesome/free-solid-svg-icons'
 import { bool, number, shape, string } from 'prop-types'
 import styled from 'styled-components'
 import withThemeContext from 'helpers/withThemeContext'
+import STATUS from 'helpers/status'
 import theme from './theme'
 
 const CapitalText = styled(Text)`
@@ -129,7 +130,7 @@ MetadataButton.defaultProps = {
   transcriberCount: 0,
   transcription: {
     pages: 0,
-    status: 'unseen',
+    status: STATUS.UNSEEN,
     transcribed_lines: 0
   }
 }

--- a/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.spec.js
+++ b/src/components/EditorHeader/components/MetadataButton/MetadataButtonContainer.spec.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import STATUS from 'helpers/status'
 import MetadataButtonContainer from './MetadataButtonContainer'
 
 let wrapper
@@ -15,7 +16,7 @@ const contextValues = {
   },
   transcriptions: {
     current: {
-      status: 'approved'
+      status: STATUS.APPROVED
     }
   }
 }

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -32,6 +32,7 @@ function usePrevious(rawValue) {
 function FilmstripViewer ({
   activeSlope,
   disabled,
+  draggable,
   images,
   isOpen,
   rearrangePages,
@@ -89,6 +90,7 @@ function FilmstripViewer ({
                 <Box border={border} key={`THUMBNAIL_${i}`} margin={{ bottom: 'xsmall' }}>
                   <FilmstripThumbnail
                     disabled={disabled}
+                    draggable={draggable}
                     hoveredIndex={hoveredIndex}
                     index={i}
                     isActive={isActive}
@@ -112,6 +114,7 @@ function FilmstripViewer ({
 
 FilmstripViewer.defaultProps = {
   disabled: false,
+  draggable: true,
   images: [],
   isOpen: true,
   selectImage: () => {},
@@ -123,6 +126,7 @@ FilmstripViewer.defaultProps = {
 
 FilmstripViewer.propTypes = {
   disabled: PropTypes.bool,
+  draggable: PropTypes.bool,
   images: PropTypes.arrayOf(PropTypes.string),
   isOpen: PropTypes.bool,
   selectImage: PropTypes.func,

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { observer } from 'mobx-react'
 import AppContext from 'store'
+import STATUS from 'helpers/status'
 import FilmstripViewer from './FilmstripViewer'
 
 function FilmstripViewerContainer({ images }) {
@@ -12,7 +13,7 @@ function FilmstripViewerContainer({ images }) {
     store.transcriptions.setActiveTranscription()
     store.transcriptions.changeIndex(page, slopeIndex)
   }
-  const inProgress = store.transcriptions.current && store.transcriptions.current.status !== 'approved'
+  const inProgress = store.transcriptions.current && store.transcriptions.current.status !== STATUS.APPROVED
 
   return  (
     <FilmstripViewer

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -12,11 +12,13 @@ function FilmstripViewerContainer({ images }) {
     store.transcriptions.setActiveTranscription()
     store.transcriptions.changeIndex(page, slopeIndex)
   }
+  const inProgress = store.transcriptions.current && store.transcriptions.current.status !== 'approved'
 
   return  (
     <FilmstripViewer
       activeSlope={store.transcriptions.slopeIndex}
       disabled={disabled}
+      draggable={inProgress}
       images={images}
       isOpen={isOpen}
       rearrangePages={store.transcriptions.rearrangePages}

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.spec.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import STATUS from 'helpers/status'
 import FilmstripViewerContainer from './FilmstripViewerContainer'
 
 let wrapper
@@ -30,5 +31,22 @@ describe('Component > FilmstripViewerContainer', function () {
     wrapper.props().selectImage()
     expect(resetSpy).toHaveBeenCalled()
     expect(changeIndexSpy).toHaveBeenCalled()
+  })
+})
+
+describe('Context > FilmstripViewerContainer', function () {
+  describe('with an approved subject', function () {
+    it('should set the draggable prop to false', function () {
+      const approvedContext = {
+        transcriptions: {
+          current: { status: STATUS.APPROVED }
+        }
+      }
+      jest
+        .spyOn(React, 'useContext')
+        .mockImplementation(() => Object.assign({}, contextValues, approvedContext ))
+      wrapper = shallow(<FilmstripViewerContainer />)
+      expect(wrapper.props().draggable).toBe(false)
+    })
   })
 })

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -2,6 +2,11 @@ import React from 'react'
 import { Box, Button, Image } from 'grommet'
 import { bool, func, number, string } from 'prop-types'
 import ThumbnailBorder from './ThumbnailBorder'
+import styled, {css} from 'styled-components'
+
+const StyledButton = styled(Button)`
+  ${css`cursor: ${props => props.draggable ? 'move' : 'cursor'};`}
+`
 
 export default function FilmstripThumbnail ({
   disabled,
@@ -37,7 +42,7 @@ export default function FilmstripThumbnail ({
   }
 
   return (
-      <Button
+      <StyledButton
         disabled={disabled}
         draggable={draggable}
         margin='xsmall'
@@ -62,7 +67,7 @@ export default function FilmstripThumbnail ({
           />
           <Image alt={`Subject Page ${page + 1}`} fit='cover' src={src} />
         </Box>
-      </Button>
+      </StyledButton>
   )
 }
 

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -4,7 +4,7 @@ import { bool, func, number, string } from 'prop-types'
 import ThumbnailBorder from './ThumbnailBorder'
 import styled, {css} from 'styled-components'
 
-const StyledButton = styled(Button)`
+export const StyledButton = styled(Button)`
   ${css`cursor: ${props => props.draggable ? 'move' : 'cursor'};`}
 `
 

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.js
@@ -5,6 +5,7 @@ import ThumbnailBorder from './ThumbnailBorder'
 
 export default function FilmstripThumbnail ({
   disabled,
+  draggable,
   hoveredIndex,
   index,
   isActive,
@@ -38,7 +39,7 @@ export default function FilmstripThumbnail ({
   return (
       <Button
         disabled={disabled}
-        draggable
+        draggable={draggable}
         margin='xsmall'
         onBlur={() => onHover(false)}
         onClick={() => selectImage(page, slopeIndex)}
@@ -67,6 +68,7 @@ export default function FilmstripThumbnail ({
 
 FilmstripThumbnail.propTypes = {
   disabled: bool,
+  draggable: bool,
   index: number,
   isActive: bool,
   rotationDegrees: number,
@@ -76,6 +78,7 @@ FilmstripThumbnail.propTypes = {
 
 FilmstripThumbnail.defaultProps = {
   disabled: false,
+  draggable: true,
   index: 0,
   isActive: false,
   rotationDegrees: null,

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import { Button } from 'grommet'
-import FilmstripThumbnail from './FilmstripThumbnail'
+import FilmstripThumbnail, { StyledButton } from './FilmstripThumbnail'
 
 const preventDefaultSpy = jest.fn()
 const rearrangePagesSpy = jest.fn()
@@ -30,7 +29,7 @@ describe('Component > FilmstripViewer', function () {
         selectImage={selectImage}
         src={'www.testlocation.com'}
       />)
-      button = wrapper.find(Button).first()
+      button = wrapper.find(StyledButton).first()
   })
 
   afterEach(() => jest.clearAllMocks());

--- a/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
+++ b/src/components/FilmstripViewer/components/FilmstripThumbnail/FilmstripThumbnail.spec.js
@@ -1,5 +1,7 @@
 import { shallow } from 'enzyme'
 import React from 'react'
+import renderer from 'react-test-renderer'
+import 'jest-styled-components'
 import FilmstripThumbnail, { StyledButton } from './FilmstripThumbnail'
 
 const preventDefaultSpy = jest.fn()
@@ -84,5 +86,25 @@ describe('Component > FilmstripViewer', function () {
   it('should perform a drag start', function () {
     button.simulate('dragstart')
     expect(setHoveredIndexSpy).toHaveBeenCalledWith(0)
+  })
+
+  describe('Props > FilmstripThumbnail', function () {
+    describe('when not draggable', function () {
+      it("should set the cursor to 'cursor'", function () {
+        wrapper = shallow(<FilmstripThumbnail draggable={false} />)
+        const Btn = wrapper.find(StyledButton).first()
+        const btnTree = renderer.create(Btn).toJSON()
+        expect(btnTree).toHaveStyleRule('cursor', 'cursor')
+      })
+    })
+
+    describe('when draggable', function () {
+      it("should set the cursor to 'move'", function () {
+        wrapper = shallow(<FilmstripThumbnail draggable />)
+        const Btn = wrapper.find(StyledButton).first()
+        const btnTree = renderer.create(Btn).toJSON()
+        expect(btnTree).toHaveStyleRule('cursor', 'move')
+      })
+    })
   })
 })

--- a/src/components/SearchModal/SearchModal.js
+++ b/src/components/SearchModal/SearchModal.js
@@ -7,7 +7,8 @@ import { Formik } from 'formik'
 import withThemeContext from '../../helpers/withThemeContext'
 import theme from './theme'
 import SearchCheckBox from './components/SearchCheckBox'
-import { FILTERS, TYPES } from 'store/SearchStore'
+import FILTERS from 'helpers/status'
+import { TYPES } from 'store/SearchStore'
 
 const CapitalText = styled(Text)`
   text-transform: uppercase;

--- a/src/helpers/status.js
+++ b/src/helpers/status.js
@@ -1,0 +1,10 @@
+const STATUS = {
+  APPROVED: 'approved',
+  FLAGGED: 'flagged',
+  IN_PROGRESS: 'in_progress',
+  LOW_CONSENSUS: 'low_consensus',
+  READY: 'ready',
+  UNSEEN: 'unseen'
+}
+
+export default STATUS

--- a/src/store/SearchStore.js
+++ b/src/store/SearchStore.js
@@ -1,17 +1,9 @@
 import { getRoot, types } from 'mobx-state-tree'
+import STATUS from 'helpers/status'
 
 const TYPES = {
   ZOONIVERSE: 'ZOONIVERSE ID',
   INTERNAL: 'INTERNAL ID'
-}
-
-const FILTERS = {
-  APPROVED: 'approved',
-  FLAGGED: 'flagged',
-  IN_PROGRESS: 'in_progress',
-  LOW_CONSENSUS: 'low_consensus',
-  READY: 'ready',
-  UNSEEN: 'unseen'
 }
 
 const SORT_VALUES = [
@@ -66,8 +58,8 @@ const SearchStore = types.model('SearchStore', {
     const transcriptions = getRoot(self).transcriptions
     transcriptions.reset()
     let queries = []
-    const approvalFilters = [FILTERS.UNSEEN, FILTERS.IN_PROGRESS, FILTERS.READY, FILTERS.APPROVED]
-    const additionalFilters = [FILTERS.FLAGGED, FILTERS.LOW_CONSENSUS]
+    const approvalFilters = [STATUS.UNSEEN, STATUS.IN_PROGRESS, STATUS.READY, STATUS.APPROVED]
+    const additionalFilters = [STATUS.FLAGGED, STATUS.LOW_CONSENSUS]
     const activeApprovalFilters = []
     const activeAdditionalFilters = []
 
@@ -162,4 +154,4 @@ const SearchStore = types.model('SearchStore', {
   }
 }))
 
-export { FILTERS, SearchStore, TYPES }
+export { SearchStore, TYPES }

--- a/src/store/SearchStore.spec.js
+++ b/src/store/SearchStore.spec.js
@@ -1,4 +1,5 @@
 import { AppStore } from './AppStore'
+import STATUS from 'helpers/status'
 
 let searchStore
 const fetchTranscriptionsSpy = jest.fn()
@@ -81,7 +82,7 @@ describe('SearchStore', function () {
 
   it('should clear a tag', function() {
     searchStore.searchTranscriptions({ approved: true })
-    searchStore.clearTag('approved')
+    searchStore.clearTag(STATUS.APPROVED)
     expect(searchStore.approved).toBe(false)
   })
 

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -6,10 +6,13 @@ import apiClient from 'panoptes-client/lib/api-client.js'
 import { reaction, toJS } from 'mobx'
 import { request } from 'graphql-request'
 import { config } from 'config'
+
 import { constructText, mapExtractsToReductions } from 'helpers/parseTranscriptionData'
 import { getPage, getSlopeLabel, isolateGroups } from 'helpers/slopeHelpers'
 import getError, { TranscriptionError } from 'helpers/getError'
 import MODALS from 'helpers/modals'
+import STATUS from 'helpers/status'
+
 import Reduction from './Reduction'
 
 let Frame = types.array(Reduction)
@@ -484,9 +487,9 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   function updateApproval(isChecked) {
     self.setActiveTranscription()
     const isAdmin = getRoot(self).projects.isAdmin
-    const query = { data: { type: 'transcriptions', attributes: { status: 'in_progress' } }}
+    const query = { data: { type: 'transcriptions', attributes: { status: STATUS.IN_PROGRESS } }}
     if (!isChecked) {
-      const newStatus = isAdmin ? 'approved' : 'ready'
+      const newStatus = isAdmin ? STATUS.APPROVED : STATUS.READY
       query.data.attributes.status = newStatus
     }
     self.current.status = query.data.attributes.status
@@ -532,13 +535,13 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   },
 
   get approved () {
-    return !!(self.current && self.current.status === 'approved')
+    return !!(self.current && self.current.status === STATUS.APPROVED)
   },
 
   get approvedCount () {
     let count = 0;
     self.all.forEach(transcription => {
-      if (transcription.status === 'approved') {
+      if (transcription.status === STATUS.APPROVED) {
         count ++
       }
     })
@@ -566,7 +569,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
   },
 
   get readyForReview () {
-    return !!(self.current && self.current.status === 'ready')
+    return !!(self.current && self.current.status === STATUS.READY)
   },
 
   get title () {

--- a/src/store/TranscriptionsStore.spec.js
+++ b/src/store/TranscriptionsStore.spec.js
@@ -3,6 +3,7 @@ import * as graphQl from 'graphql-request'
 import apiClient from 'panoptes-client/lib/api-client.js';
 import { mockExtract } from 'helpers/parseTranscriptionData.spec'
 import mockJWT from 'helpers/mockJWT'
+import STATUS from 'helpers/status'
 import { AppStore } from './AppStore'
 import TranscriptionFactory from './factories/transcription'
 
@@ -99,7 +100,7 @@ const multipleTranscriptionsStub = {
     {
       body: JSON.stringify(
         {
-          data: [TranscriptionFactory.build(), TranscriptionFactory.build({ id: '2', attributes: { status: 'approved', subject_id: '2', text: new Map() }})],
+          data: [TranscriptionFactory.build(), TranscriptionFactory.build({ id: '2', attributes: { status: STATUS.APPROVED, subject_id: '2', text: new Map() }})],
           meta: {
             pagination: { last: 1 }
           }


### PR DESCRIPTION
This PR addresses an item in #165. Once a subject is approved, volunteers shouldn't be able to make any edits. That includes rearranging pages. There is also a bit of refactoring here. The PR covers several items:

- When transcription is approved, disable rearranging pages
- When subject is not approved, show a "move" cursor when hovering over a filmstrip thumbnail
- Refactoring: Abstract out all "status" strings into a single file.