### PR TITLE
Remember Parsed Extracts (Undo Button Bug)

### DIFF
--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -446,10 +446,12 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     }
   }
 
-  function setTextObject(text) {
-    self.current.text.set(self.currentKey, text)
-    self.setParsedExtracts()
-    self.saveTranscription()
+  function setTextObject(newState) {
+    if (!Ramda.equals(self.currentTranscriptions, newState)) {
+      self.current.text.set(self.currentKey, newState)
+      self.setParsedExtracts()
+      self.saveTranscription()
+    }
   }
 
   function setTranscription(transcription) {


### PR DESCRIPTION
This PR fixes one bug with the undo button. 

**The problem:**
Sometimes, pressing the undo button would transform the transcription state unexpectedly. For example, you may press the undo button and see a transcription consensus text does not match the transcription options given in the line. 

_How to replicate this:_
- Try rearranging the rows of a transcription several times. Press the undo button a few times to visit a past state. Maybe try to open a transcription line a couple times to really throw off the state. Eventually, you'll see some consensus text that doesn't match the options given.

- You can also break the editor if you:
  - Change the page (clicking on a new image on the filmstrip viewer at the bottom of the page)
  - Press the undo button to go back to the previous page
  - Click on any transcribed line to view the transcription options

**Why does this happen?**
The `undoManager` allows you to ignore tracking some state changes. This is present in the `TranscriptionsStore` wherever you see `undoManager.withoutUndo`.

The issue is that we were using `withoutUndo` every time the `setParsedExtracts` function was being called. That means the parsed extracts were not changing whenever you press the "undo" button. Because of this, we would set the transcription to a past state, but we weren't changing the transcription options/extracts along with it. 

The parsed extracts should only be hidden from the undo button on first load, because we always want there to be _some_ extracts, and we don't want to press undo back to a state where there were zero extracts. Aside from that, we should be tracking changes to the extracts whenever the state changes.