### PR TITLE
[Do Not Merge] Invert Open and Close Icons on FilmstripViewer

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -505,7 +505,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 iEoiXx"
             />
             <svg
-              aria-label="FormDown"
+              aria-label="FormUp"
               className="StyledIcon-ofa7kd-0 iOkQrb"
               viewBox="0 0 24 24"
             >
@@ -514,6 +514,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
                 points="18 9 12 15 6 9"
                 stroke="#000"
                 strokeWidth="2"
+                transform="matrix(1 0 0 -1 0 24)"
               />
             </svg>
           </div>

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -68,7 +68,7 @@ function FilmstripViewer ({
           /> )}
         <Button
           disabled={disabled}
-          icon={isOpen ? <FormDown /> : <FormUp />}
+          icon={isOpen ? <FormUp /> : <FormDown />}
           label={<Uppercase>{actionText} Filmstrip</Uppercase>}
           gap='xsmall'
           onClick={() => { setOpen(!isOpen) }}


### PR DESCRIPTION
The FilmstripViewer was showing the wrong icons when the filmstrip viewer was open and closed:

Incorrect:
![Screen Shot 2020-07-02 at 9 42 22 AM](https://user-images.githubusercontent.com/14099077/86373126-aaf3e800-bc48-11ea-9f8a-a4227a3718c2.png)


Correct:
![Screen Shot 2020-07-02 at 9 42 33 AM](https://user-images.githubusercontent.com/14099077/86373144-b0513280-bc48-11ea-90ce-5ec901dacaf5.png)

