### PR TITLE
Fix Logout Crash on Editor Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "stage": "export REACT_APP_ENV=development; export PATH_ROOT=preview.zooniverse.org/alice; yarn build && yarn _publish",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --coverage --watchAll=false --silent",
+    "test": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "stage": "export REACT_APP_ENV=development; export PATH_ROOT=preview.zooniverse.org/alice; yarn build && yarn _publish",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --coverage --watchAll=false",
+    "test": "react-scripts test --coverage --watchAll=false --silent",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/src/components/Badge/BadgeContainer.js
+++ b/src/components/Badge/BadgeContainer.js
@@ -11,9 +11,7 @@ function BadgeContainer ({ onAbout }) {
   const disabled = store.aggregations.showModal || store.transcriptions.isActive
   const src = user && user.avatar_src
   const signOut = () => {
-    if (store.transcriptions.current && !store.transcriptions.lockedByDifferentUser) {
-      store.transcriptions.unlockTranscription()
-    }
+    store.transcriptions.unlockTranscription()
     store.auth.logout()
   }
 

--- a/src/components/Badge/BadgeContainer.js
+++ b/src/components/Badge/BadgeContainer.js
@@ -9,8 +9,13 @@ function BadgeContainer ({ onAbout }) {
   const user = store.auth.user
 
   const disabled = store.aggregations.showModal || store.transcriptions.isActive
-  const signOut = store.auth.logout
   const src = user && user.avatar_src
+  const signOut = () => {
+    if (store.transcriptions.current && !store.transcriptions.lockedByDifferentUser) {
+      store.transcriptions.unlockTranscription()
+    }
+    store.auth.logout()
+  }
 
   return (
     <Badge

--- a/src/components/Badge/BadgeContainer.spec.js
+++ b/src/components/Badge/BadgeContainer.spec.js
@@ -5,13 +5,15 @@ import Badge from './Badge'
 
 let wrapper
 let badgeComponent
+const logoutSpy = jest.fn()
+const unlockTranscriptionSpy = jest.fn()
 
 const contextValues = {
   aggregations: {
     showModal: false
   },
   auth: {
-    logout: () => {},
+    logout: logoutSpy,
     user: { avatar_src: 'source.jpg' },
     userName: 'Test_User'
   },
@@ -19,7 +21,8 @@ const contextValues = {
     role: 'Researcher'
   },
   transcriptions: {
-    isActive: false
+    isActive: false,
+    unlockTranscription: unlockTranscriptionSpy
   }
 }
 
@@ -40,19 +43,26 @@ describe('Component > BadgeContainer', function () {
     expect(badgeComponent).toHaveLength(1)
   })
 
-  it('should pass the name prop', function () {
-    const signOut = badgeComponent.props().signOut
-    expect(signOut).toBe(contextValues.auth.logout)
-    expect(signOut).toBeInstanceOf(Function)
+  describe('props > signOut', function () {
+    it('should pass the signOut prop', function () {
+      const signOut = badgeComponent.props().signOut
+      expect(signOut).toBeInstanceOf(Function)
+    })
+
+    it('should trigger two store functions', function () {
+      badgeComponent.props().signOut()
+      expect(logoutSpy).toHaveBeenCalled()
+      expect(unlockTranscriptionSpy).toHaveBeenCalled()
+    })
   })
 
-  it('should pass the signOut prop', function () {
+  it('should pass the src prop', function () {
     const src = badgeComponent.props().src
     expect(src).toBe(contextValues.auth.user.avatar_src)
     expect(typeof src).toBe('string')
   })
 
-  it('should pass the src prop', function () {
+  it('should pass the name prop', function () {
     const name = badgeComponent.props().name
     expect(name).toBe(contextValues.auth.userName)
     expect(typeof name).toBe('string')

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -32,7 +32,7 @@ function Editor ({ match, testTime }) {
     const setResources = async () => {
       await store.subjects.fetchSubject(match.params.subject)
       await store.getResources(match.params)
-      if (store.transcriptions.lockedByDifferentUser) {
+      if (!store.transcriptions.lockedByCurrentUser) {
         store.modal.toggleModal(MODALS.LOCKED)
       }
     }

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -56,7 +56,7 @@ function Editor ({ match, testTime }) {
     return () => {
       store.image.reset()
 
-      if (!store.transcriptions.lockedByDifferentUser) {
+      if (store.auth.user && !store.transcriptions.lockedByDifferentUser) {
         store.transcriptions.unlockTranscription()
       }
       window.removeEventListener('beforeunload', store.transcriptions.unlockTranscription);

--- a/src/screens/Editor/Editor.js
+++ b/src/screens/Editor/Editor.js
@@ -56,9 +56,7 @@ function Editor ({ match, testTime }) {
     return () => {
       store.image.reset()
 
-      if (store.auth.user && !store.transcriptions.lockedByDifferentUser) {
-        store.transcriptions.unlockTranscription()
-      }
+      store.transcriptions.unlockTranscription()
       window.removeEventListener('beforeunload', store.transcriptions.unlockTranscription);
       window.removeEventListener('visibilitychange', handleTimeCheck)
     }

--- a/src/screens/Editor/Editor.spec.js
+++ b/src/screens/Editor/Editor.spec.js
@@ -67,7 +67,7 @@ const contextValues = {
     current: undefined,
     extracts: [],
     index: 0,
-    lockedByDifferentUser: true,
+    lockedByCurrentUser: false,
     setActiveTranscription: setActiveTranscriptionSpy,
     slopeKeys: [],
     unlockTranscription: unlockTranscriptionSpy
@@ -113,18 +113,13 @@ describe('Component > Editor', function () {
       it('should show the locked transcription modal', function () {
         expect(toggleModalSpy).toHaveBeenCalledWith(MODALS.LOCKED)
       })
-
-      it('should not attempt to unlock the transcription', function () {
-        wrapper.unmount()
-        expect(unlockTranscriptionSpy).not.toHaveBeenCalled()
-      })
     })
 
     describe('with an unlocked transcription', function () {
       beforeEach(async function () {
         jest.clearAllMocks()
         const lockedValues = Object.assign(contextValues)
-        lockedValues.transcriptions.lockedByDifferentUser = false
+        lockedValues.transcriptions.lockedByCurrentUser = true
         jest
           .spyOn(React, 'useContext')
           .mockImplementation(() => Object.assign({}, lockedValues))


### PR DESCRIPTION
Closes #179 

This PR fixes the issue mentioned above and also handles a few more issues:

- Refactors the code by changing `lockedByDifferentUser` to `lockedByCurrentUser`. 
    - I know this has gone both ways in the past, but I now think `lockedByCurrentUser` makes for a cleaner conditional
- Refactor some of the testing in the `TranscriptionsStore`
    - Initially, that store set up the primary "fetch transcription" test as retrieving a transcription you were locked out of. This is more of an edge case and should be separated into a different `describe` block.