### PR TITLE
Remove Filmstrip Open/Close Functionality

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -482,42 +482,6 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
         >
           All Pages
         </span>
-        <button
-          className="StyledButton-sc-323bzc-0 dmFHgS"
-          disabled={false}
-          onBlur={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOut={[Function]}
-          onMouseOver={[Function]}
-          type="button"
-        >
-          <div
-            className="StyledBox-sc-13pk1d4-0 jHQJnz"
-          >
-            <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-brqgnP gxqauL"
-            >
-              Collapse
-               Filmstrip
-            </span>
-            <div
-              className="StyledBox__StyledBoxGap-sc-13pk1d4-1 iEoiXx"
-            />
-            <svg
-              aria-label="FormDown"
-              className="StyledIcon-ofa7kd-0 iOkQrb"
-              viewBox="0 0 24 24"
-            >
-              <polyline
-                fill="none"
-                points="18 9 12 15 6 9"
-                stroke="#000"
-                strokeWidth="2"
-              />
-            </svg>
-          </div>
-        </button>
       </div>
       <div
         className="StyledBox-sc-13pk1d4-0 ilHtzj"
@@ -725,7 +689,7 @@ exports[`Storyshots LineViewer Default 1`] = `
         <div
           className="StyledBox-sc-13pk1d4-0 iRPRCt"
         >
-          
+
           <div
             className="StyledBox-sc-13pk1d4-0 ekjAwv"
           >
@@ -1435,7 +1399,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
       <span
         className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
-        This subject cannot be accessed because 
+        This subject cannot be accessed because
         <strong />
          is currently accessing it.
       </span>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -1483,16 +1483,16 @@ exports[`Storyshots SubjectViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm cGINmZ"
+        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-csuQGl dlqfCR"
       >
         <div
-          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo iWvEYT"
+          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm bUdQZZ"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-csuQGl jfGFKk"
+            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-gipzik gWRpcz"
           />
           <div
-            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-bRBYWo sc-hzDkRC fcssmf"
+            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-Rmtcm sc-bRBYWo dNnMia"
           />
         </div>
         <div

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -471,7 +471,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-cMljjf hwFcyK"
+      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-brqgnP jxxQpd"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 cGDWft"
@@ -689,7 +689,7 @@ exports[`Storyshots LineViewer Default 1`] = `
         <div
           className="StyledBox-sc-13pk1d4-0 iRPRCt"
         >
-
+          
           <div
             className="StyledBox-sc-13pk1d4-0 ekjAwv"
           >
@@ -943,7 +943,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
             className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
           />
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
           >
             Find a specific subject
           </span>
@@ -961,7 +961,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 iEMnku"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1029,7 +1029,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 bgTRhM"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1067,7 +1067,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
             />
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
             >
               Filter subject list by status
             </span>
@@ -1348,7 +1348,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="button"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
                 >
                   Close
                 </span>
@@ -1363,7 +1363,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="submit"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
                 >
                   Search
                 </span>
@@ -1397,9 +1397,9 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
       >
-        This subject cannot be accessed because
+        This subject cannot be accessed because 
         <strong />
          is currently accessing it.
       </span>
@@ -1407,7 +1407,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
       >
         For access, ask them to close their version.
       </span>
@@ -1556,7 +1556,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         By unapproving this subject, the subject's data will be unavailable for future downloads until re-marked as approved.
       </span>
@@ -1564,7 +1564,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         This action can be reversed at any time.
       </span>

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -1,18 +1,12 @@
 import React from 'react'
-import { Box, Button, Text } from 'grommet'
+import { Box, Text } from 'grommet'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { observer } from 'mobx-react'
 import isEqual from 'helpers/isEqual'
-import { FormDown, FormUp } from 'grommet-icons'
 import { spotInGroup, getPage, getSlopeLabel } from 'helpers/slopeHelpers'
 import FilmstripThumbnail from './components/FilmstripThumbnail'
-import StepNavigation from '../StepNavigation'
 import Overlay from '../Overlay'
-
-const Uppercase = styled(Text)`
-  text-transform: uppercase;
-`
 
 const RelativeBox = styled(Box)`
   position: relative;
@@ -34,15 +28,12 @@ function FilmstripViewer ({
   disabled,
   draggable,
   images,
-  isOpen,
   rearrangePages,
   selectImage,
-  setOpen,
   slopeDefinitions,
   slopeKeys,
   subjectIndex
 }) {
-  const actionText = isOpen ? 'Collapse' : 'Expand';
   const [hoveredIndex, setHoveredIndex] = React.useState()
   const [slopeValues, setSlopeValues] = React.useState(slopeKeys)
   const previous = usePrevious(slopeKeys)
@@ -52,31 +43,13 @@ function FilmstripViewer ({
   }
 
   const handlePageRearrangement = () => rearrangePages(slopeValues)
-  const steps = images.map((src,i) => i)
 
   return (
     <RelativeBox background='#FFFFFF' pad='xsmall' round={{ size: 'xsmall', corner: 'top' }}>
       {disabled && <Overlay />}
       <Box direction='row' justify='between'>
         <Text size='1em'>All Pages</Text>
-        {!isOpen && (
-          <StepNavigation
-            activeStep={subjectIndex}
-            disabled={disabled}
-            setStep={selectImage}
-            steps={steps}
-            totalPages={steps.length}
-          /> )}
-        <Button
-          disabled={disabled}
-          icon={isOpen ? <FormDown /> : <FormUp />}
-          label={<Uppercase>{actionText} Filmstrip</Uppercase>}
-          gap='xsmall'
-          onClick={() => { setOpen(!isOpen) }}
-          plain
-          reverse />
       </Box>
-      {isOpen && (
           <Box direction='row' wrap>
             {slopeValues.map((key, i) => {
               const page = getPage(key)
@@ -104,10 +77,9 @@ function FilmstripViewer ({
                     slopeValues={slopeValues}
                     src={image}
                   />
-                </Box>)
-            })}
+                </Box>
+            )})}
           </Box>
-      )}
     </RelativeBox>
   )
 }
@@ -116,9 +88,7 @@ FilmstripViewer.defaultProps = {
   disabled: false,
   draggable: true,
   images: [],
-  isOpen: true,
   selectImage: () => {},
-  setOpen: () => {},
   setSlopeKeys: () => {},
   slopeKeys: [],
   subjectIndex: 0
@@ -128,9 +98,7 @@ FilmstripViewer.propTypes = {
   disabled: PropTypes.bool,
   draggable: PropTypes.bool,
   images: PropTypes.arrayOf(PropTypes.string),
-  isOpen: PropTypes.bool,
   selectImage: PropTypes.func,
-  setOpen: PropTypes.func,
   setSlopeKeys: PropTypes.func,
   slopeKeys: PropTypes.arrayOf(PropTypes.string),
   subjectIndex: PropTypes.number

--- a/src/components/FilmstripViewer/FilmstripViewer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.spec.js
@@ -13,7 +13,6 @@ import StepNavigation from '../StepNavigation'
 import Overlay from '../Overlay'
 
 let wrapper;
-let setOpen
 const slopeDefinitions = {
   'frame0.0': '0',
   'frame1.0': '90',
@@ -27,14 +26,12 @@ const slopeKeys = ['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0', 'frame4.0', '
 
 describe('Component > FilmstripViewer', function () {
   beforeEach(function() {
-    setOpen = jest.fn()
     jest
       .spyOn(React, 'useState')
       .mockImplementation((init) => [init, jest.fn()])
     wrapper = shallow(
       <FilmstripViewer
         images={[Page1, Page2, Page3, Page4, Page5, Page6]}
-        setOpen={setOpen}
         slopeDefinitions={slopeDefinitions}
         slopeKeys={slopeKeys}
       />)
@@ -42,23 +39,9 @@ describe('Component > FilmstripViewer', function () {
 
   it('renders without crashing', function () {})
 
-  it('shows Thumbnails when open', function () {
+  it('shows Thumbnails', function () {
     const thumbnailLength = wrapper.find(FilmstripThumbnail).length
     expect(thumbnailLength).toEqual(6)
-  })
-
-  it('hides Thumbnails and shows the StepNavigation when closed', function () {
-    wrapper.setProps({ isOpen: false })
-    const thumbnailLength = wrapper.find(FilmstripThumbnail).length
-    expect(thumbnailLength).toEqual(0)
-    const navigatorPresence = wrapper.find(StepNavigation).length
-    expect(navigatorPresence).toEqual(1)
-  })
-
-  it('calls the setOpen function with close button press', function () {
-    const closeButton = wrapper.find(Button)
-    closeButton.simulate('click')
-    expect(setOpen).toHaveBeenCalled()
   })
 
   it('should show an overlay when disabled', function () {

--- a/src/components/FilmstripViewer/FilmstripViewer.spec.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.spec.js
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import React from 'react'
 import { Button } from 'grommet'
 import FilmstripViewer from './FilmstripViewer'
@@ -26,10 +26,7 @@ const slopeKeys = ['frame0.0', 'frame1.0', 'frame2.0', 'frame3.0', 'frame4.0', '
 
 describe('Component > FilmstripViewer', function () {
   beforeEach(function() {
-    jest
-      .spyOn(React, 'useState')
-      .mockImplementation((init) => [init, jest.fn()])
-    wrapper = shallow(
+    wrapper = mount(
       <FilmstripViewer
         images={[Page1, Page2, Page3, Page4, Page5, Page6]}
         slopeDefinitions={slopeDefinitions}

--- a/src/components/FilmstripViewer/FilmstripViewerContainer.js
+++ b/src/components/FilmstripViewer/FilmstripViewerContainer.js
@@ -5,7 +5,6 @@ import STATUS from 'helpers/status'
 import FilmstripViewer from './FilmstripViewer'
 
 function FilmstripViewerContainer({ images }) {
-  const [isOpen, setOpen] = React.useState(true)
   const store = React.useContext(AppContext)
   const disabled = store.aggregations.showModal || store.transcriptions.isActive
   const selectImage = (page, slopeIndex) => {
@@ -21,10 +20,8 @@ function FilmstripViewerContainer({ images }) {
       disabled={disabled}
       draggable={inProgress}
       images={images}
-      isOpen={isOpen}
       rearrangePages={store.transcriptions.rearrangePages}
       selectImage={selectImage}
-      setOpen={setOpen}
       slopeDefinitions={store.transcriptions.slopeDefinitions}
       slopeKeys={store.transcriptions.slopeKeys}
       subjectIndex={store.transcriptions.index}


### PR DESCRIPTION
Closes #177 
Supersedes #178 

Following up on the issue above, the Flimstrip Viewer doesn't have any reason to open and collapse as a panel. This will also help with some of the display discrepancies in the viewer. 

I've also adjusted the tests here a bit. We really shouldn't be mocking out `React.useState`. I erroneously did this with I first started using hooks, but mocking the function keeps React from performing as it naturally does and leads to irregular tests. Removing the mock here allows the tests to respond to state changes when using `mount`, which also improved coverage.