### PR TITLE
Fix Bug When Reordering Rows of Different Heights 

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -11,7 +11,7 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
       className="StyledBox-sc-13pk1d4-0 bdFdoP"
     >
       <div
-        className="StyledBox-sc-13pk1d4-0 dPQuSd sc-jzJRlG byHcWR"
+        className="StyledBox-sc-13pk1d4-0 dPQuSd sc-cSHVUG hDUXUW"
       >
         <div
           className="StyledBox-sc-13pk1d4-0 ikTqht"
@@ -44,7 +44,7 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
             </button>
           </div>
           <div
-            className="StyledBox-sc-13pk1d4-0 tkzRw sc-kAzzGY cHmBTk"
+            className="StyledBox-sc-13pk1d4-0 tkzRw sc-chPdSV lxGhg"
           >
             <div
               className="StyledBox-sc-13pk1d4-0 joGoBe"
@@ -56,7 +56,7 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
                   className="StyledBox-sc-13pk1d4-0 fGMGTD"
                 >
                   <h6
-                    className="sc-bZQynM kvEEqW"
+                    className="sc-gzVnrw kDhxVb"
                   >
                     Aggregated Transcription
                   </h6>
@@ -65,7 +65,7 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
                   className="StyledBox-sc-13pk1d4-0 fWrrBh"
                 >
                   <h6
-                    className="sc-bZQynM kvEEqW"
+                    className="sc-gzVnrw kDhxVb"
                   >
                     Flag
                   </h6>
@@ -74,7 +74,7 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
                   className="StyledBox-sc-13pk1d4-0 dzunxD"
                 >
                   <h6
-                    className="sc-bZQynM sc-gzVnrw goYdle"
+                    className="sc-gzVnrw sc-htoDjs GbAiK"
                   >
                     Consensus Score
                   </h6>
@@ -84,7 +84,7 @@ exports[`Storyshots AggregatedTranscriptions Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 kLQRpX"
               />
               <div
-                className="StyledBox-sc-13pk1d4-0 kbrZBJ sc-EHOje kKWYcL"
+                className="StyledBox-sc-13pk1d4-0 kbrZBJ sc-bZQynM evmlAb"
               >
                 <span
                   className="StyledText-sc-1sadyjn-0 fNQaFh"
@@ -113,7 +113,7 @@ exports[`Storyshots AggregationSettings Default 1`] = `
       className="StyledBox-sc-13pk1d4-0 jxCWxi"
     >
       <div
-        className="StyledBox-sc-13pk1d4-0 dMvAxT sc-jKJlTe MPVAE"
+        className="StyledBox-sc-13pk1d4-0 dMvAxT sc-eNQAEJ esYNcD"
       >
         <svg
           aria-hidden="true"
@@ -209,7 +209,7 @@ exports[`Storyshots AggregationSettings Default 1`] = `
                       type="button"
                     >
                       <div
-                        className="StyledBox-sc-13pk1d4-0 htLYVV sc-kgoBCf fDGffR"
+                        className="StyledBox-sc-13pk1d4-0 htLYVV sc-kGXeez fOyJew"
                       >
                         <img
                           alt="Optics Aggregation Example"
@@ -245,7 +245,7 @@ exports[`Storyshots AggregationSettings Default 1`] = `
                       type="button"
                     >
                       <div
-                        className="StyledBox-sc-13pk1d4-0 htLYVV sc-kGXeez lgIlUY"
+                        className="StyledBox-sc-13pk1d4-0 htLYVV sc-kpOJdX kdgkNy"
                       >
                         <img
                           alt="DBScan Aggregation Example"
@@ -509,7 +509,7 @@ exports[`Storyshots HeaderButtons LayoutButton 1`] = `
       className="StyledBox-sc-13pk1d4-0 jHQJnz"
     >
       <span
-        className="StyledText-sc-1sadyjn-0 gcASOG sc-eNQAEJ jtFbJk"
+        className="StyledText-sc-1sadyjn-0 gcASOG sc-hMqMXs hCtDtz"
       >
         Layout
       </span>
@@ -622,7 +622,7 @@ exports[`Storyshots HeaderButtons UndoButton 1`] = `
       className="StyledBox-sc-13pk1d4-0 jHQJnz"
     >
       <span
-        className="StyledText-sc-1sadyjn-0 gcASOG sc-eNQAEJ jtFbJk"
+        className="StyledText-sc-1sadyjn-0 gcASOG sc-hMqMXs hCtDtz"
       >
         Undo
       </span>
@@ -660,7 +660,7 @@ exports[`Storyshots LineViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 biltor sc-fjdhpX fCEyoV"
+      className="StyledBox-sc-13pk1d4-0 biltor sc-jzJRlG byHcWR"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 eTTqCm"
@@ -672,7 +672,7 @@ exports[`Storyshots LineViewer Default 1`] = `
             className="StyledBox-sc-13pk1d4-0 fWrrBh"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 dxiclx sc-VigVT cDzzLD"
+              className="StyledText-sc-1sadyjn-0 dxiclx sc-jTzLTM krJVzu"
               size="0.6em"
             >
               Selected Transcription
@@ -689,7 +689,7 @@ exports[`Storyshots LineViewer Default 1`] = `
         <div
           className="StyledBox-sc-13pk1d4-0 iRPRCt"
         >
-          
+
           <div
             className="StyledBox-sc-13pk1d4-0 ekjAwv"
           >
@@ -758,7 +758,7 @@ exports[`Storyshots LineViewer Default 1`] = `
             type="button"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 fNQaFh sc-VigVT cDzzLD"
+              className="StyledText-sc-1sadyjn-0 fNQaFh sc-jTzLTM krJVzu"
               size="xsmall"
             >
               Cancel
@@ -779,7 +779,7 @@ exports[`Storyshots LineViewer Default 1`] = `
             type="button"
           >
             <span
-              className="StyledText-sc-1sadyjn-0 fNQaFh sc-VigVT cDzzLD"
+              className="StyledText-sc-1sadyjn-0 fNQaFh sc-jTzLTM krJVzu"
               size="xsmall"
             >
               Add Line
@@ -803,7 +803,7 @@ exports[`Storyshots MarkApproved Default 1`] = `
     onClick={[Function]}
   >
     <span
-      className="StyledText-sc-1sadyjn-0 gcASOG sc-hMqMXs isvcEd"
+      className="StyledText-sc-1sadyjn-0 gcASOG sc-kEYyzF ggEPv"
     >
       Ready For Review
     </span>
@@ -863,7 +863,7 @@ exports[`Storyshots MetadataButton Default 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="svg-inline--fa fa-info fa-w-6 sc-eHgmQL tiSJc"
+            className="svg-inline--fa fa-info fa-w-6 sc-cvbbAY josHqt"
             data-icon="info"
             data-prefix="fas"
             focusable="false"
@@ -1399,7 +1399,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
       <span
         className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
       >
-        This subject cannot be accessed because 
+        This subject cannot be accessed because
         <strong />
          is currently accessing it.
       </span>

--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -471,7 +471,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
     className="StyledBox-sc-13pk1d4-0 iNPZuM"
   >
     <div
-      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-brqgnP jxxQpd"
+      className="StyledBox-sc-13pk1d4-0 kFLDHg sc-cMljjf hwFcyK"
     >
       <div
         className="StyledBox-sc-13pk1d4-0 cGDWft"
@@ -689,7 +689,7 @@ exports[`Storyshots LineViewer Default 1`] = `
         <div
           className="StyledBox-sc-13pk1d4-0 iRPRCt"
         >
-
+          
           <div
             className="StyledBox-sc-13pk1d4-0 ekjAwv"
           >
@@ -943,7 +943,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
             className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
           />
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
           >
             Find a specific subject
           </span>
@@ -961,7 +961,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 iEMnku"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1029,7 +1029,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 className="StyledBox-sc-13pk1d4-0 bgTRhM"
               >
                 <div
-                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-gPEVay kIjqED"
+                  className="StyledBox-sc-13pk1d4-0 hEeEAx FormField__FormFieldBox-m9hood-0 btlOdO sc-iRbamj ffLvVD"
                 >
                   <label
                     className="StyledText-sc-1sadyjn-0 cxYjCj"
@@ -1067,7 +1067,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
               className="StyledBox__StyledBoxGap-sc-13pk1d4-1 bloGGK"
             />
             <span
-              className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+              className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
             >
               Filter subject list by status
             </span>
@@ -1348,7 +1348,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="button"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
                 >
                   Close
                 </span>
@@ -1363,7 +1363,7 @@ exports[`Storyshots SearchModalContainer Default 1`] = `
                 type="submit"
               >
                 <span
-                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+                  className="StyledText-sc-1sadyjn-0 bmpSIR sc-gPEVay eWCTaR"
                 >
                   Search
                 </span>
@@ -1397,9 +1397,9 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
-        This subject cannot be accessed because
+        This subject cannot be accessed because 
         <strong />
          is currently accessing it.
       </span>
@@ -1407,7 +1407,7 @@ exports[`Storyshots SubjectLockedModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-cMljjf djFewk"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
       >
         For access, ask them to close their version.
       </span>
@@ -1483,16 +1483,16 @@ exports[`Storyshots SubjectViewer Default 1`] = `
         </div>
       </div>
       <div
-        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-csuQGl dlqfCR"
+        className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm cGINmZ"
       >
         <div
-          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-Rmtcm bUdQZZ"
+          className="StyledBox-sc-13pk1d4-0 lfMSfr sc-bRBYWo iWvEYT"
         >
           <div
-            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-gipzik gWRpcz"
+            className="StyledBox-sc-13pk1d4-0 kYbCiA sc-csuQGl jfGFKk"
           />
           <div
-            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-Rmtcm sc-bRBYWo dNnMia"
+            className="StyledBox-sc-13pk1d4-0 fWrrBh sc-bRBYWo sc-hzDkRC fcssmf"
           />
         </div>
         <div
@@ -1556,7 +1556,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         By unapproving this subject, the subject's data will be unavailable for future downloads until re-marked as approved.
       </span>
@@ -1564,7 +1564,7 @@ exports[`Storyshots UnapproveModal Default 1`] = `
         className="StyledBox__StyledBoxGap-sc-13pk1d4-1 cDZOKh"
       />
       <span
-        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jAaTju lmAtdT"
+        className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eJgHCP"
       >
         This action can be reversed at any time.
       </span>

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTable.js
@@ -30,6 +30,7 @@ function TranscriptionTable ({ activeSlope, data, isViewer, setActiveTranscripti
   }, [data, dragID])
   const background = emptyData ? { color: 'light-2', opacity: 'strong' } : {}
 
+
   return (
     <Box round={{ size: 'xsmall', corner: 'bottom' }}>
       <Box align='center' direction='row' margin={{ horizontal: 'xsmall' }} pad={{ vertical: 'xsmall' }}>

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
@@ -17,7 +17,6 @@ const MoveBox = styled(Box)`
 
 const PointerBox = styled(Box)`
   ${css`cursor: ${props => props.hover ? 'pointer' : 'default'};`}
-  ${css`pointer-events: ${props => props.hover ? 'all' : 'none'};`}
 `
 
 function handleDragStart(dragID, setDragID, setHover) {
@@ -59,17 +58,8 @@ function TranscriptionTableRow({
   return (
     <Box
       border={{ color: '#ECECEC', side: 'bottom' }}
-      draggable={!isViewer}
       elevation={elevation}
-      flex={false}
       gap='xsmall'
-      onDragEnd={() => {
-        setTextObject(data);
-        setDragID(null)
-      }}
-      onDragEnter={(e) => handleDragEnter(e, index, data, dragID, moveData, setDragID)}
-      onDragOver={(e) => stopEvents(e)}
-      onDragStart={() => handleDragStart(index, setDragID, setHover)}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       margin={{ right: '0.15em' }}
@@ -79,8 +69,17 @@ function TranscriptionTableRow({
       <PointerBox
         align='center'
         direction='row'
+        draggable={!isViewer}
         hover={isHover}
-        onMouseUp={() => setActiveTranscription(index)}>
+        onDragEnd={() => {
+          setTextObject(data);
+          setDragID(null)
+        }}
+        onDragLeave={(e) => handleDragEnter(e, index, data, dragID, moveData, setDragID)}
+        onDragOver={(e) => stopEvents(e)}
+        onDragStart={() => handleDragStart(index, setDragID, setHover)}
+        onMouseUp={() => setActiveTranscription(index)}
+      >
         <MoveBox
           hover={isHover}
           isViewer={isViewer}

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
@@ -8,6 +8,7 @@ import { Flags } from './Flags'
 
 const QuietBox = styled(Box)`
   pointer-events: none;
+  ${css`pointer-events: ${props => props.hover ? 'all' : 'none'};`}
 `
 
 const MoveBox = styled(Box)`
@@ -60,6 +61,7 @@ function TranscriptionTableRow({
   const hamburgerColor = isHover || isDragging ? 'black' : 'transparent'
   const elevation = isHover || isDragging ? 'small' : 'none'
   const round = isHover || isDragging ? 'xsmall' : 'none'
+  const visibleText = datum.edited_consensus_text || datum.consensus_text
 
   return (
     <Box
@@ -99,8 +101,8 @@ function TranscriptionTableRow({
             </QuietBox>
           )}
         </MoveBox>
-        <QuietBox basis='72%'>
-          <StyledText>{datum.edited_consensus_text || datum.consensus_text}</StyledText>
+        <QuietBox hover={isHover} basis='72%'>
+          <StyledText title={visibleText}>{visibleText}</StyledText>
         </QuietBox>
         <QuietBox basis='10%'>
           <Flags datum={datum} />

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.js
@@ -19,6 +19,12 @@ const PointerBox = styled(Box)`
   ${css`cursor: ${props => props.hover ? 'pointer' : 'default'};`}
 `
 
+const StyledText = styled(Text)`
+  overflow: hidden;
+  white-space:nowrap;
+  text-overflow:ellipsis;
+`
+
 function handleDragStart(dragID, setDragID, setHover) {
   setDragID(dragID)
   setHover(false)
@@ -75,7 +81,7 @@ function TranscriptionTableRow({
           setTextObject(data);
           setDragID(null)
         }}
-        onDragLeave={(e) => handleDragEnter(e, index, data, dragID, moveData, setDragID)}
+        onDragEnter={(e) => handleDragEnter(e, index, data, dragID, moveData, setDragID)}
         onDragOver={(e) => stopEvents(e)}
         onDragStart={() => handleDragStart(index, setDragID, setHover)}
         onMouseUp={() => setActiveTranscription(index)}
@@ -94,7 +100,7 @@ function TranscriptionTableRow({
           )}
         </MoveBox>
         <QuietBox basis='72%'>
-          <Text>{datum.edited_consensus_text || datum.consensus_text}</Text>
+          <StyledText>{datum.edited_consensus_text || datum.consensus_text}</StyledText>
         </QuietBox>
         <QuietBox basis='10%'>
           <Flags datum={datum} />

--- a/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.spec.js
+++ b/src/components/AggregatedTranscriptions/components/TranscriptionTable/TranscriptionTableRow.spec.js
@@ -7,6 +7,7 @@ import mockData from './mockData'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 
+let pointerBox;
 let wrapper;
 let useStateSpy;
 
@@ -34,6 +35,7 @@ describe('Component > TranscriptionTable', function () {
         setDragID={setDragIDSpy}
         setTextObject={setTextObjectSpy}
       />);
+    pointerBox = wrapper.find(PointerBox).first()
   })
 
   it('should render without crashing', function () {
@@ -41,7 +43,7 @@ describe('Component > TranscriptionTable', function () {
   })
 
   it('should call setDragID on drag end', function () {
-    wrapper.simulate('dragend')
+    pointerBox.simulate('dragend')
     expect(setTextObjectSpy).toHaveBeenCalledWith(mockData)
     expect(setDragIDSpy).toHaveBeenCalledWith(null)
   })
@@ -57,20 +59,20 @@ describe('Component > TranscriptionTable', function () {
   })
 
   it('should call handleDragStart on dragStart', function () {
-    wrapper.simulate('dragstart')
+    pointerBox.simulate('dragstart')
     expect(setState).toHaveBeenCalledWith(false)
     expect(setDragIDSpy).toHaveBeenCalledWith(0)
   })
 
   it('should call handleDragEnter on dragEnter', function () {
-    wrapper.simulate('dragenter', mockEvent)
+    pointerBox.simulate('dragenter', mockEvent)
     expect(preventDefaultSpy).toHaveBeenCalled()
     expect(setDragIDSpy).toHaveBeenCalledWith(0)
     expect(moveDataSpy).toHaveBeenCalled()
   })
 
   it('should call stopEvent on dragOver', function () {
-    wrapper.simulate('dragover', mockEvent)
+    pointerBox.simulate('dragover', mockEvent)
     expect(preventDefaultSpy).toHaveBeenCalled()
     expect(stopPropagationSpy).toHaveBeenCalled()
   })
@@ -92,7 +94,6 @@ describe('Component > TranscriptionTable', function () {
     const Pointer = wrapper.find(PointerBox).first()
     const group = renderer.create(Pointer).toJSON()
     expect(group).toHaveStyleRule('cursor', 'default')
-    expect(group).toHaveStyleRule('pointer-events', 'none')
   })
 
   describe('should correctly style components on hover', function () {
@@ -122,7 +123,6 @@ describe('Component > TranscriptionTable', function () {
       const Pointer = wrapper.find(PointerBox).first()
       const group = renderer.create(Pointer).toJSON()
       expect(group).toHaveStyleRule('cursor', 'pointer')
-      expect(group).toHaveStyleRule('pointer-events', 'all')
     })
   })
 


### PR DESCRIPTION
Closes #189 

Following up on a conversation in the issue above, this PR gives an ending ellipsis to long text rows. It also attached drag handlers to the transcription row text to further try to avoid the issue seen above. I believe there's an edge case where the same bug can occur when the mouse is held at the border between two rows.

<img width="460" alt="Screen Shot 2020-07-24 at 11 53 52 AM" src="https://user-images.githubusercontent.com/14099077/88415810-bbf5cc00-cda4-11ea-9bc9-9c4e327e432e.png">
