### PR TITLE
Refer to subject sets as groups

### DIFF
--- a/src/components/EditorHeader/components/HeaderButton/DownloadSetDataContainer.js
+++ b/src/components/EditorHeader/components/HeaderButton/DownloadSetDataContainer.js
@@ -12,7 +12,7 @@ function DownloadSetDataContainer({ disabled }) {
   return (
     <HeaderButton
       disabled={disableButton}
-      label='Download Approved Subject Set Data'
+      label='Download Approved Group Data'
       onClick={onClick}
     />
   )

--- a/src/components/Modals/DownloadDataModal/DownloadDataModal.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModal.js
@@ -11,7 +11,7 @@ export default function DownloadDataModal({
   onDownload,
   transcriptionCount
 }) {
-  const text = entireGroup ? 'Download approved subject set data' : 'Download subject data'
+  const text = entireGroup ? 'Download approved group data' : 'Download subject data'
   return (
     <Box
       background='white'

--- a/src/components/Modals/DownloadDataModal/DownloadDataModal.spec.js
+++ b/src/components/Modals/DownloadDataModal/DownloadDataModal.spec.js
@@ -44,7 +44,7 @@ describe('Component > DownloadDataModal', function () {
 
     it('should set the correct text', function () {
       const header = wrapper.find(Text).first().props()
-      expect(header.children).toBe('Download approved subject set data')
+      expect(header.children).toBe('Download approved group data')
     })
 
     it('should display the approved count', function () {


### PR DESCRIPTION
Closes #195 

Parts of the app still refer to "groups" as "subject sets." Although they are somewhat similar, we're trying to make a distinction between the two here. 

### The difference between "groups" and "subject sets"
Panoptes uses the term "subject sets" to refer to a collection of subjects that a workflow can reference. This may be a collection of images from a certain time period, a collection of subjects from a particular work, whatever grouping method is preferred. 

ALICE allows subjects to be grouped differently using a `group_id` field defined on each subject. This can help researchers find subjects in ALICE using that `group_id` field when searching. This was preferred so institutions could defined the `group_id` value using a value known within the institution and defining that value in the metadata before uploading the subjects to Panoptes. Otherwise, research groups were at the whim of whatever unique value would be assigned to a subject set after it is uploaded. 

For all intents and purposes, ALICE should always refer to subject "groups," not "subject sets."