### PR TITLE
Troubleshoot Page Deletion

### DIFF
--- a/src/__snapshots__/Storyshots.test.js.snap
+++ b/src/__snapshots__/Storyshots.test.js.snap
@@ -492,7 +492,7 @@ exports[`Storyshots FilmstripViewer Default 1`] = `
           type="button"
         >
           <span
-            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ hGYXTl"
+            className="StyledText-sc-1sadyjn-0 bmpSIR sc-jDwBTQ eYRRwn"
           >
             Delete Pages
           </span>

--- a/src/components/FilmstripViewer/FilmstripViewer.js
+++ b/src/components/FilmstripViewer/FilmstripViewer.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box, Button, Text } from 'grommet'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import PropTypes from 'prop-types'
 import { observer } from 'mobx-react'
 import isEqual from 'helpers/isEqual'
@@ -14,6 +14,7 @@ const RelativeBox = styled(Box)`
 
 const Uppercase = styled(Text)`
   text-transform: uppercase;
+  ${css`text-decoration: ${props => props.canDelete ? 'underline' : 'inherit'};`}
 `
 
 function usePrevious(rawValue) {
@@ -56,7 +57,7 @@ function FilmstripViewer ({
       <Box direction='row' justify='between'>
         <Text size='1em'>All Pages</Text>
         <Button
-          label={<Uppercase>Delete Pages</Uppercase>}
+          label={<Uppercase canDelete={canDelete}>Delete Pages</Uppercase>}
           onClick={() => setCanDelete(!canDelete)}
           plain
         />

--- a/src/components/Modals/DeletePageModal/DeletePageModal.js
+++ b/src/components/Modals/DeletePageModal/DeletePageModal.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Box, Button, Text } from 'grommet'
-import { func } from 'prop-types'
+import { func, shape, string } from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons'
 import styled from 'styled-components'
+import CONTENT from './content'
 
 const StyledText = styled(Text)`
   line-height: 1.5rem;
@@ -13,7 +14,7 @@ const Uppercase = styled(Text)`
   text-transform: uppercase;
 `
 
-export default function DeletePageModal({ onClose, onDelete }) {
+export default function DeletePageModal({ content, onClose, onDelete }) {
   return (
     <Box
       background='white'
@@ -24,7 +25,7 @@ export default function DeletePageModal({ onClose, onDelete }) {
       width='medium'
     >
       <Box direction='row' gap='small' justify='between'>
-        <Text size='large'>Delete this page?</Text>
+        <Text size='large'>{content.title}</Text>
         <Button
           a11yTitle="Close Delete Page Modal"
           icon={<FontAwesomeIcon icon={faTimesCircle} size='xs' />}
@@ -33,13 +34,8 @@ export default function DeletePageModal({ onClose, onDelete }) {
         />
       </Box>
 
-      <StyledText>
-        The selected page contains transcribed text data. Are you sure
-        you want to delete it?
-      </StyledText>
-      <StyledText>
-        This action can be undone using the Undo button in the toolbar.
-      </StyledText>
+      <StyledText>{content.firstParagraph}</StyledText>
+      <StyledText>{content.secondParagraph}</StyledText>
       <Box direction='row' justify='between' margin={{ top: 'small' }}>
         <Button
           a11yTitle="Close Delete Page Modal"
@@ -59,11 +55,17 @@ export default function DeletePageModal({ onClose, onDelete }) {
 }
 
 DeletePageModal.defaultProps = {
+  content: CONTENT.withDuplicates,
   onClose: () => {},
   onDelete: () => {}
 }
 
 DeletePageModal.propTypes = {
+  content: shape({
+    title: string,
+    firstParagraph: string,
+    secondParagraph: string
+  }),
   onClose: func,
   onDelete: func
 }

--- a/src/components/Modals/DeletePageModal/DeletePageModalContainer.js
+++ b/src/components/Modals/DeletePageModal/DeletePageModalContainer.js
@@ -1,6 +1,16 @@
 import React from 'react'
 import AppContext from 'store'
 import DeletePageModal from './DeletePageModal'
+import CONTENT from './content'
+import { getPage } from 'helpers/slopeHelpers'
+
+function lastInstanceOnPage(allKeys, currentKey) {
+  let instances = 0
+  allKeys.forEach(key => {
+    if (getPage(key) === getPage(currentKey)) instances += 1
+  })
+  return instances <= 1
+}
 
 export default function DeletePageModalContainer() {
   const store = React.useContext(AppContext)
@@ -9,10 +19,14 @@ export default function DeletePageModalContainer() {
     store.transcriptions.deletePage()
     onClose()
   }
-
+  const slopeKeys = store.transcriptions.slopeKeys
+  const currentKey = store.transcriptions.currentKey
+  const lastInstance = lastInstanceOnPage(slopeKeys, currentKey)
+  let content = lastInstance ? CONTENT.withoutDuplicates : CONTENT.withDuplicates
 
   return (
     <DeletePageModal
+      content={content}
       onClose={onClose}
       onDelete={onDelete}
     />

--- a/src/components/Modals/DeletePageModal/DeletePageModalContainer.js
+++ b/src/components/Modals/DeletePageModal/DeletePageModalContainer.js
@@ -2,15 +2,7 @@ import React from 'react'
 import AppContext from 'store'
 import DeletePageModal from './DeletePageModal'
 import CONTENT from './content'
-import { getPage } from 'helpers/slopeHelpers'
-
-function lastInstanceOnPage(allKeys, currentKey) {
-  let instances = 0
-  allKeys.forEach(key => {
-    if (getPage(key) === getPage(currentKey)) instances += 1
-  })
-  return instances <= 1
-}
+import { lastInstanceOnPage } from 'helpers/slopeHelpers'
 
 export default function DeletePageModalContainer() {
   const store = React.useContext(AppContext)
@@ -20,8 +12,8 @@ export default function DeletePageModalContainer() {
     onClose()
   }
   const slopeKeys = store.transcriptions.slopeKeys
-  const currentKey = store.transcriptions.currentKey
-  const lastInstance = lastInstanceOnPage(slopeKeys, currentKey)
+  const currentIndex = store.transcriptions.index
+  const lastInstance = lastInstanceOnPage(slopeKeys, currentIndex)
   let content = lastInstance ? CONTENT.withoutDuplicates : CONTENT.withDuplicates
 
   return (

--- a/src/components/Modals/DeletePageModal/content.js
+++ b/src/components/Modals/DeletePageModal/content.js
@@ -1,0 +1,14 @@
+const content = {
+  withDuplicates: {
+    title: 'Delete this page?',
+    firstParagraph: 'The selected page contains transcribed text data. Are you sure you want to delete it?',
+    secondParagraph: 'This action can be undone using the Undo button in the toolbar.'
+  },
+  withoutDuplicates: {
+    title: 'Delete contents of this page?',
+    firstParagraph: 'The selected page contains transcribed text data. Are you sure you want to delete these transcriptions?',
+    secondParagraph: 'This action can be undone using the Undo button in the toolbar.'
+  }
+}
+
+export default content

--- a/src/components/Modals/DeletePageModal/content.js
+++ b/src/components/Modals/DeletePageModal/content.js
@@ -6,7 +6,10 @@ const content = {
   },
   withoutDuplicates: {
     title: 'Delete contents of this page?',
-    firstParagraph: 'The selected page contains transcribed text data. Are you sure you want to delete these transcriptions?',
+    firstParagraph: `
+      The selected page contains transcribed text data. Are you sure you want to delete these transcriptions?
+      Deleting a frame removes associated contents only; non-duplicate images cannot be removed.
+    `,
     secondParagraph: 'This action can be undone using the Undo button in the toolbar.'
   }
 }

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -16,7 +16,7 @@ export function getSlopeLabel(key) {
   return parseInt(key[key.length - 1])
 }
 
-export function lastInstanceOnPage(allKeys, page) {
+export function lastInstanceOnPage(allKeys = [], page) {
   let instances = 0
   allKeys.forEach(key => {
     if (getPage(key) === page) instances += 1

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -16,6 +16,14 @@ export function getSlopeLabel(key) {
   return parseInt(key[key.length - 1])
 }
 
+export function lastInstanceOnPage(allKeys, page) {
+  let instances = 0
+  allKeys.forEach(key => {
+    if (getPage(key) === page) instances += 1
+  })
+  return instances <= 1
+}
+
 export function spotInGroup(slopes, index) {
   const currentPage = getPage(slopes[index])
 

--- a/src/helpers/slopeHelpers.js
+++ b/src/helpers/slopeHelpers.js
@@ -6,8 +6,8 @@ export const BORDER_MAP = {
 }
 
 export function getPage(key) {
-  const dotIndex = key.indexOf('.')
-  if (dotIndex === -1) return 0
+  let dotIndex = key.indexOf('.')
+  if (dotIndex === -1) dotIndex = key.length
   return parseInt(key[dotIndex - 1])
 }
 

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -8,7 +8,7 @@ import { request } from 'graphql-request'
 import { config } from 'config'
 
 import { constructText, mapExtractsToReductions } from 'helpers/parseTranscriptionData'
-import { getPage, getSlopeLabel, isolateGroups } from 'helpers/slopeHelpers'
+import { getPage, getSlopeLabel, isolateGroups, lastInstanceOnPage } from 'helpers/slopeHelpers'
 import getError, { TranscriptionError } from 'helpers/getError'
 import MODALS from 'helpers/modals'
 import STATUS from 'helpers/status'
@@ -152,11 +152,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     let page = self.current.text.get(self.currentKey)
     page = page.filter(line => line.slope_label !== self.slopeIndex)
 
-    let instancesOfPage = 0
-    self.slopeKeys.forEach(key => {
-      if (getPage(key) === self.index) instancesOfPage += 1
-    })
-    const lastTranscriptionsOnPage = instancesOfPage <= 1
+    const lastTranscriptionsOnPage = lastInstanceOnPage(self.slopeKeys, self.index)
 
     if (page.length) {
       self.current.text.set(self.currentKey, page)

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -142,6 +142,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     if (Number.isInteger(self.activeTranscriptionIndex)) {
       const page = self.current.text.get(self.currentKey)
       page.splice(self.activeTranscriptionIndex, 1)
+      self.getSlopeKeys()
       self.saveTranscription()
       self.setActiveTranscription()
     }
@@ -174,6 +175,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     const newKey = self.slopeKeys.find(key => getSlopeLabel(key) !== self.slopeIndex)
     self.index = getPage(newKey)
     self.slopeIndex = getSlopeLabel(newKey)
+    self.saveTranscription()
   }
 
   const reaggregateDBScan = flow(function * reaggregateDBScan(params) {
@@ -305,8 +307,8 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
 
     framesWithoutTranscriptions.forEach(emptyFrame => {
       const emptyFramePage = getPage(emptyFrame)
-      const pageIsInAllSlopeKeys = allSlopeKeys.some(key => getPage(key) === emptyFramePage)
-      if (!pageIsInAllSlopeKeys) {
+      const pageExistsInSlopeKeys = allSlopeKeys.some(key => getPage(key) === emptyFramePage)
+      if (!pageExistsInSlopeKeys) {
         const slopeKey = `frame${emptyFramePage}.0`
         allSlopeKeys.push(slopeKey)
         slopeDefinitions[slopeKey] = 0

--- a/src/store/TranscriptionsStore.js
+++ b/src/store/TranscriptionsStore.js
@@ -148,16 +148,19 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     }
   }
 
+  function chooseNewActivePage() {
+    const newKey = self.slopeKeys.find(key => getSlopeLabel(key) !== self.slopeIndex)
+    self.index = getPage(newKey)
+    self.slopeIndex = getSlopeLabel(newKey)
+  }
+
   function deletePage() {
     let page = self.current.text.get(self.currentKey)
     page = page.filter(line => line.slope_label !== self.slopeIndex)
 
     const lastTranscriptionsOnPage = lastInstanceOnPage(self.slopeKeys, self.index)
 
-    if (page.length) {
-      self.current.text.set(self.currentKey, page)
-      self.getSlopeKeys()
-    } else if (lastTranscriptionsOnPage) {
+    if (page.length || lastTranscriptionsOnPage) {
       self.current.text.set(self.currentKey, page)
     } else {
       if (self.current.frame_order.length) {
@@ -166,11 +169,9 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
       self.current.text.forEach((value, key) => {
         if (key === self.currentKey) detach(value)
       })
-      self.getSlopeKeys()
     }
-    const newKey = self.slopeKeys.find(key => getSlopeLabel(key) !== self.slopeIndex)
-    self.index = getPage(newKey)
-    self.slopeIndex = getSlopeLabel(newKey)
+    self.getSlopeKeys()
+    if (!lastTranscriptionsOnPage) self.chooseNewActivePage()
     self.saveTranscription()
   }
 
@@ -564,6 +565,7 @@ const TranscriptionsStore = types.model('TranscriptionsStore', {
     changeIndex,
     checkForFlagUpdate,
     checkIfLocked,
+    chooseNewActivePage,
     createTranscription: (transcription, lastModified) => undoManager.withoutUndo(() => createTranscription(transcription, lastModified)),
     deleteCurrentLine,
     deletePage,


### PR DESCRIPTION
For clarification:
**frame** means the different images of a multi-image subject
**page** means the different options available via the filmstrip viewer

Some errors existed with the page deletion functionality. Including:
- When deleting the final instance of a **page** without a duplicate **frame**, the **page** should still remain active
- Copy on the Delete Page modal should be different if you're deleting the final **page** that doesn't have a **frame** duplicate
- After deleting a **page** the transcription should be saved
- Deleting the final line of a **page** should delete the entire **page** if **frame** duplicates exist
- Previously, if we deleted a **page** that didn't have any **frame** duplicates, then we deleted another **page**, that previous **page** would disappear. That should no longer happen.

I'll go ahead and stage this to [alice.preview.zooniverse.org](alice.preview.zooniverse.org) for testing