### PR TITLE
fix project avatars image src

### DIFF
--- a/src/screens/ProjectsIndex/components/ProjectCard/ProjectCard.js
+++ b/src/screens/ProjectsIndex/components/ProjectCard/ProjectCard.js
@@ -10,7 +10,7 @@ const CapitalText = styled(Text)`
 `
 
 function ProjectCard({ history, project }) {
-  const imageSrc = project.avatar_src && project.avatar_src.length ? `//${project.avatar_src}` : SimplePattern
+  const imageSrc = project.avatar_src && project.avatar_src.length ? project.avatar_src : SimplePattern
   const onClick = e => {
     history.push(`/projects/${project.id}/workflows`)
   }

--- a/src/screens/ProjectsIndex/components/ProjectCard/ProjectCard.spec.js
+++ b/src/screens/ProjectsIndex/components/ProjectCard/ProjectCard.spec.js
@@ -37,7 +37,7 @@ describe('Component > ProjectCard', function () {
 
   it('should format the project src correctly', function () {
     wrapper = shallow(<ProjectCard project={project} />);
-    expect(wrapper.find(Image).first().props().src).toBe(`//${project.avatar_src}`)
+    expect(wrapper.find(Image).first().props().src).toBe(project.avatar_src)
   })
 
   it('should call store functions with onClick', function () {


### PR DESCRIPTION
closes #207 as the API now returns the project image avatar URL with the scheme (https) we can use this instead of `//` relative URL from the domain.